### PR TITLE
Client: Add RelayService for WebSocket relay connections

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "prepare": "effect-language-service patch && bun run setup:hooks",
     "setup:hooks": "mkdir -p .git/hooks && cp scripts/pre-push .git/hooks/pre-push && chmod +x .git/hooks/pre-push",
     "test": "bun test",
-    "typecheck": "tsc --noEmit --incremental",
+    "typecheck": "tsc --noEmit -p tsconfig.check.json",
     "verify": "bun run typecheck && bun test",
     "build:check": "bun build src/index.ts --outdir /dev/null --target node 2>&1 | head -100",
     "build": "bun build src/index.ts --outdir dist --target node"

--- a/src/client/RelayService.test.ts
+++ b/src/client/RelayService.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Tests for RelayService
+ */
+import { test, expect, describe, beforeAll, afterAll } from "bun:test"
+import { Effect, Layer } from "effect"
+import { Schema } from "@effect/schema"
+import { RelayService, makeRelayService } from "./RelayService.js"
+import { startTestRelay, type RelayHandle } from "../relay/index.js"
+import { CryptoService, CryptoServiceLive } from "../services/CryptoService.js"
+import { EventService, EventServiceLive } from "../services/EventService.js"
+import { EventKind, Filter, SubscriptionId, type NostrEvent } from "../core/Schema.js"
+
+const decodeKind = Schema.decodeSync(EventKind)
+const decodeFilter = Schema.decodeSync(Filter)
+const decodeSubId = Schema.decodeSync(SubscriptionId)
+
+// Test layers
+const TestLayer = Layer.merge(
+  CryptoServiceLive,
+  EventServiceLive.pipe(Layer.provide(CryptoServiceLive))
+)
+
+// Create test event helper
+const createTestEvent = (content: string = "Test event") =>
+  Effect.gen(function* () {
+    const crypto = yield* CryptoService
+    const events = yield* EventService
+    const privateKey = yield* crypto.generatePrivateKey()
+
+    return yield* events.createEvent(
+      {
+        kind: decodeKind(1),
+        content,
+      },
+      privateKey
+    )
+  })
+
+describe("RelayService", () => {
+  let relay: RelayHandle
+  let port: number
+
+  beforeAll(async () => {
+    port = 11000 + Math.floor(Math.random() * 10000)
+    relay = await startTestRelay(port)
+  })
+
+  afterAll(async () => {
+    await Effect.runPromise(relay.stop())
+  })
+
+  describe("connection", () => {
+    test("connects to relay", async () => {
+      const program = Effect.gen(function* () {
+        const relayService = yield* RelayService
+        yield* relayService.connect()
+        const state = yield* relayService.connectionState()
+        expect(state).toBe("connected")
+        yield* relayService.disconnect()
+      })
+
+      const RelayLayer = makeRelayService({
+        url: `ws://localhost:${port}`,
+        reconnect: false,
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(RelayLayer)))
+    })
+
+    test("reports disconnected state initially", async () => {
+      const program = Effect.gen(function* () {
+        const relayService = yield* RelayService
+        const state = yield* relayService.connectionState()
+        expect(state).toBe("disconnected")
+      })
+
+      const RelayLayer = makeRelayService({
+        url: `ws://localhost:${port}`,
+        reconnect: false,
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(RelayLayer)))
+    })
+
+    test("fails to connect to invalid URL", async () => {
+      const program = Effect.gen(function* () {
+        const relayService = yield* RelayService
+        yield* relayService.connect()
+      })
+
+      const RelayLayer = makeRelayService({
+        url: "ws://localhost:1", // Invalid port
+        reconnect: false,
+      })
+
+      const result = await Effect.runPromise(
+        program.pipe(
+          Effect.provide(RelayLayer),
+          Effect.either
+        )
+      )
+
+      expect(result._tag).toBe("Left")
+    })
+  })
+
+  describe("publish", () => {
+    test("publishes event and receives OK", async () => {
+      const program = Effect.gen(function* () {
+        const relayService = yield* RelayService
+        const event = yield* createTestEvent("Publish test")
+
+        yield* relayService.connect()
+        const result = yield* relayService.publish(event)
+
+        expect(result.accepted).toBe(true)
+        yield* relayService.disconnect()
+      })
+
+      const RelayLayer = makeRelayService({
+        url: `ws://localhost:${port}`,
+        reconnect: false,
+      })
+
+      await Effect.runPromise(
+        program.pipe(
+          Effect.provide(RelayLayer),
+          Effect.provide(TestLayer)
+        )
+      )
+    })
+
+    test("receives rejection for invalid event", async () => {
+      const program = Effect.gen(function* () {
+        const relayService = yield* RelayService
+        const event = yield* createTestEvent("Invalid test")
+
+        // Tamper with content to invalidate signature
+        const tampered = {
+          ...event,
+          content: "Tampered content",
+        } as NostrEvent
+
+        yield* relayService.connect()
+        const result = yield* relayService.publish(tampered)
+
+        expect(result.accepted).toBe(false)
+        expect(result.message).toContain("invalid")
+        yield* relayService.disconnect()
+      })
+
+      const RelayLayer = makeRelayService({
+        url: `ws://localhost:${port}`,
+        reconnect: false,
+      })
+
+      await Effect.runPromise(
+        program.pipe(
+          Effect.provide(RelayLayer),
+          Effect.provide(TestLayer)
+        )
+      )
+    })
+  })
+
+  describe("subscribe", () => {
+    test("creates subscription and can unsubscribe", async () => {
+      const program = Effect.gen(function* () {
+        const relayService = yield* RelayService
+
+        yield* relayService.connect()
+
+        // Subscribe to kind 1
+        const sub = yield* relayService.subscribe([decodeFilter({ kinds: [decodeKind(1)] })])
+
+        expect(sub.id).toBeDefined()
+        expect(sub.events).toBeDefined()
+        expect(sub.unsubscribe).toBeDefined()
+
+        yield* sub.unsubscribe()
+        yield* relayService.disconnect()
+      })
+
+      const RelayLayer = makeRelayService({
+        url: `ws://localhost:${port}`,
+        reconnect: false,
+      })
+
+      await Effect.runPromise(
+        program.pipe(Effect.provide(RelayLayer))
+      )
+    })
+
+    test("unsubscribe stops receiving events", async () => {
+      const program = Effect.gen(function* () {
+        const relayService = yield* RelayService
+
+        yield* relayService.connect()
+
+        const sub = yield* relayService.subscribe([decodeFilter({ kinds: [decodeKind(1)] })])
+        yield* sub.unsubscribe()
+
+        // Subscription should be cleaned up
+        yield* relayService.disconnect()
+      })
+
+      const RelayLayer = makeRelayService({
+        url: `ws://localhost:${port}`,
+        reconnect: false,
+      })
+
+      await Effect.runPromise(
+        program.pipe(
+          Effect.provide(RelayLayer),
+          Effect.provide(TestLayer)
+        )
+      )
+    })
+
+    test("supports custom subscription ID", async () => {
+      const program = Effect.gen(function* () {
+        const relayService = yield* RelayService
+
+        yield* relayService.connect()
+
+        const sub = yield* relayService.subscribe([decodeFilter({ kinds: [decodeKind(1)] })], decodeSubId("custom-sub-id"))
+
+        expect(sub.id).toBe(decodeSubId("custom-sub-id"))
+
+        yield* sub.unsubscribe()
+        yield* relayService.disconnect()
+      })
+
+      const RelayLayer = makeRelayService({
+        url: `ws://localhost:${port}`,
+        reconnect: false,
+      })
+
+      await Effect.runPromise(
+        program.pipe(Effect.provide(RelayLayer))
+      )
+    })
+  })
+
+  describe("multiple subscriptions", () => {
+    test("supports multiple concurrent subscriptions", async () => {
+      const program = Effect.gen(function* () {
+        const relayService = yield* RelayService
+
+        yield* relayService.connect()
+
+        const sub1 = yield* relayService.subscribe([decodeFilter({ kinds: [decodeKind(1)] })], decodeSubId("sub-1"))
+        const sub2 = yield* relayService.subscribe([decodeFilter({ kinds: [decodeKind(1)] })], decodeSubId("sub-2"))
+
+        expect(sub1.id).toBe(decodeSubId("sub-1"))
+        expect(sub2.id).toBe(decodeSubId("sub-2"))
+
+        yield* sub1.unsubscribe()
+        yield* sub2.unsubscribe()
+        yield* relayService.disconnect()
+      })
+
+      const RelayLayer = makeRelayService({
+        url: `ws://localhost:${port}`,
+        reconnect: false,
+      })
+
+      await Effect.runPromise(
+        program.pipe(Effect.provide(RelayLayer))
+      )
+    })
+  })
+})

--- a/src/client/RelayService.ts
+++ b/src/client/RelayService.ts
@@ -1,0 +1,471 @@
+/**
+ * RelayService
+ *
+ * Client-side relay connection service with WebSocket management,
+ * automatic reconnection, and subscription tracking.
+ */
+import { Context, Effect, Layer, Queue, Stream } from "effect"
+import { Schema } from "@effect/schema"
+import {
+  ConnectionError,
+  TimeoutError,
+  SubscriptionError,
+} from "../core/Errors.js"
+import {
+  RelayMessage,
+  NostrEvent,
+  Filter,
+  SubscriptionId,
+  EventId,
+} from "../core/Schema.js"
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/** Connection state */
+export type ConnectionState = "disconnected" | "connecting" | "connected"
+
+/** Configuration for relay connection */
+export interface RelayConnectionConfig {
+  readonly url: string
+  readonly reconnect?: boolean
+  readonly maxReconnectAttempts?: number
+  readonly initialReconnectDelay?: number
+  readonly maxReconnectDelay?: number
+}
+
+/** Result of publishing an event */
+export interface PublishResult {
+  readonly accepted: boolean
+  readonly message: string
+}
+
+/** Subscription handle returned by subscribe */
+export interface SubscriptionHandle {
+  readonly id: SubscriptionId
+  readonly events: Stream.Stream<NostrEvent, SubscriptionError>
+  readonly unsubscribe: () => Effect.Effect<void>
+}
+
+/** Internal subscription state */
+interface SubscriptionState {
+  readonly id: SubscriptionId
+  readonly filters: readonly Filter[]
+  readonly queue: Queue.Queue<NostrEvent>
+  readonly eoseReceived: boolean
+}
+
+/** Pending OK resolver */
+interface PendingOk {
+  resolve: (result: PublishResult) => void
+  reject: (error: Error) => void
+}
+
+// =============================================================================
+// Service Interface
+// =============================================================================
+
+export interface RelayService {
+  readonly _tag: "RelayService"
+
+  /**
+   * Get the relay URL
+   */
+  readonly url: string
+
+  /**
+   * Get current connection state
+   */
+  connectionState(): Effect.Effect<ConnectionState>
+
+  /**
+   * Connect to the relay
+   */
+  connect(): Effect.Effect<void, ConnectionError>
+
+  /**
+   * Disconnect from the relay
+   */
+  disconnect(): Effect.Effect<void>
+
+  /**
+   * Publish an event to the relay
+   */
+  publish(event: NostrEvent): Effect.Effect<PublishResult, ConnectionError | TimeoutError>
+
+  /**
+   * Subscribe to events matching filters
+   */
+  subscribe(
+    filters: readonly Filter[],
+    subscriptionId?: string
+  ): Effect.Effect<SubscriptionHandle, ConnectionError>
+
+  /**
+   * Wait for a specific event ID to be acknowledged
+   */
+  waitForOk(eventId: EventId, timeoutMs?: number): Effect.Effect<PublishResult, TimeoutError>
+}
+
+// =============================================================================
+// Service Tag
+// =============================================================================
+
+export const RelayService = Context.GenericTag<RelayService>("RelayService")
+
+// =============================================================================
+// Service Implementation
+// =============================================================================
+
+const make = (config: RelayConnectionConfig) =>
+  Effect.gen(function* () {
+    // Use plain JS state for simplicity in WebSocket callbacks
+    let state: ConnectionState = "disconnected"
+    let ws: WebSocket | null = null
+    const subscriptions = new Map<string, SubscriptionState>()
+    const pendingOks = new Map<string, PendingOk>()
+    let reconnectTimeout: ReturnType<typeof setTimeout> | null = null
+    let reconnectAttempts = 0
+
+    // Subscription ID generation
+    let subCounter = 0
+    const generateSubId = (): string => {
+      subCounter++
+      return `sub_${Date.now()}_${subCounter}`
+    }
+
+    // Handle incoming message (called synchronously from WebSocket)
+    const handleMessage = (data: string): void => {
+      try {
+        const parsed = JSON.parse(data)
+        const decodeResult = Schema.decodeUnknownSync(RelayMessage)(parsed)
+
+        const [type] = decodeResult
+
+        switch (type) {
+          case "EVENT": {
+            const [, subId, event] = decodeResult
+            const sub = subscriptions.get(subId)
+            if (sub) {
+              Effect.runSync(Queue.offer(sub.queue, event))
+            }
+            break
+          }
+
+          case "EOSE": {
+            const [, subId] = decodeResult
+            const sub = subscriptions.get(subId)
+            if (sub && !sub.eoseReceived) {
+              subscriptions.set(subId, { ...sub, eoseReceived: true })
+            }
+            break
+          }
+
+          case "OK": {
+            const [, eventId, accepted, message] = decodeResult
+            const pending = pendingOks.get(eventId)
+            if (pending) {
+              pending.resolve({ accepted, message })
+              pendingOks.delete(eventId)
+            }
+            break
+          }
+
+          case "CLOSED": {
+            const [, subId] = decodeResult
+            const sub = subscriptions.get(subId)
+            if (sub) {
+              Effect.runSync(Queue.shutdown(sub.queue))
+              subscriptions.delete(subId)
+            }
+            break
+          }
+
+          case "NOTICE": {
+            const [, message] = decodeResult
+            console.warn(`[Relay Notice] ${config.url}: ${message}`)
+            break
+          }
+        }
+      } catch {
+        // Ignore parse errors for robustness
+      }
+    }
+
+    // Send a message to the relay
+    const sendMessage = (message: unknown): Effect.Effect<void, ConnectionError> =>
+      Effect.sync(() => {
+        if (!ws || ws.readyState !== WebSocket.OPEN) {
+          throw new ConnectionError({ message: "Not connected", url: config.url })
+        }
+        ws.send(JSON.stringify(message))
+      }).pipe(
+        Effect.catchAllDefect((error) =>
+          Effect.fail(
+            new ConnectionError({
+              message: error instanceof Error ? error.message : "Send failed",
+              url: config.url,
+            })
+          )
+        )
+      )
+
+    // Reconnection logic
+    const scheduleReconnect = (): void => {
+      if (config.reconnect === false) return
+
+      const maxAttempts = config.maxReconnectAttempts ?? 10
+      if (reconnectAttempts >= maxAttempts) return
+
+      const initialDelay = config.initialReconnectDelay ?? 1000
+      const maxDelay = config.maxReconnectDelay ?? 30000
+      const delay = Math.min(initialDelay * Math.pow(2, reconnectAttempts), maxDelay)
+
+      reconnectAttempts++
+      reconnectTimeout = setTimeout(() => {
+        Effect.runFork(
+          connectWs().pipe(
+            Effect.tap(() =>
+              Effect.sync(() => {
+                reconnectAttempts = 0
+                // Resubscribe to all active subscriptions
+                for (const [, sub] of subscriptions) {
+                  if (ws) {
+                    ws.send(JSON.stringify(["REQ", sub.id, ...sub.filters]))
+                  }
+                }
+              })
+            ),
+            Effect.catchAll(() =>
+              Effect.sync(() => {
+                scheduleReconnect()
+              })
+            )
+          )
+        )
+      }, delay)
+    }
+
+    // Connect to WebSocket
+    const connectWs = (): Effect.Effect<void, ConnectionError> =>
+      Effect.async<void, ConnectionError>((resume) => {
+        try {
+          const socket = new WebSocket(config.url)
+
+          socket.onopen = () => {
+            ws = socket
+            state = "connected"
+            resume(Effect.void)
+          }
+
+          socket.onerror = () => {
+            resume(
+              Effect.fail(new ConnectionError({ message: "WebSocket error", url: config.url }))
+            )
+          }
+
+          socket.onclose = () => {
+            ws = null
+            state = "disconnected"
+            scheduleReconnect()
+          }
+
+          socket.onmessage = (event) => {
+            const data = typeof event.data === "string" ? event.data : event.data.toString()
+            handleMessage(data)
+          }
+
+          // Cleanup on interrupt
+          return Effect.sync(() => {
+            if (socket.readyState === WebSocket.CONNECTING) {
+              socket.close()
+            }
+          })
+        } catch (error) {
+          resume(
+            Effect.fail(
+              new ConnectionError({
+                message: error instanceof Error ? error.message : "Connection failed",
+                url: config.url,
+              })
+            )
+          )
+          return Effect.void
+        }
+      })
+
+    // Public API
+    const connect: RelayService["connect"] = () =>
+      Effect.gen(function* () {
+        if (state === "connected") return
+
+        state = "connecting"
+        yield* connectWs()
+      })
+
+    const disconnect: RelayService["disconnect"] = () =>
+      Effect.sync(() => {
+        // Cancel reconnection
+        if (reconnectTimeout) {
+          clearTimeout(reconnectTimeout)
+          reconnectTimeout = null
+        }
+        reconnectAttempts = 0
+
+        // Close WebSocket
+        if (ws) {
+          ws.close()
+          ws = null
+        }
+
+        // Clear subscriptions
+        for (const [, sub] of subscriptions) {
+          Effect.runSync(Queue.shutdown(sub.queue))
+        }
+        subscriptions.clear()
+
+        // Reject pending OKs
+        for (const [, pending] of pendingOks) {
+          pending.reject(new Error("Disconnected"))
+        }
+        pendingOks.clear()
+
+        state = "disconnected"
+      })
+
+    const publish: RelayService["publish"] = (event) =>
+      Effect.gen(function* () {
+        yield* sendMessage(["EVENT", event])
+        return yield* waitForOk(event.id, 10000)
+      })
+
+    const waitForOk: RelayService["waitForOk"] = (eventId, timeoutMs = 10000) =>
+      Effect.async<PublishResult, TimeoutError>((resume) => {
+        const timeoutHandle = setTimeout(() => {
+          pendingOks.delete(eventId)
+          resume(
+            Effect.fail(
+              new TimeoutError({
+                message: `Timeout waiting for OK for event ${eventId}`,
+                durationMs: timeoutMs,
+              })
+            )
+          )
+        }, timeoutMs)
+
+        pendingOks.set(eventId, {
+          resolve: (result) => {
+            clearTimeout(timeoutHandle)
+            resume(Effect.succeed(result))
+          },
+          reject: (error) => {
+            clearTimeout(timeoutHandle)
+            resume(
+              Effect.fail(
+                new TimeoutError({
+                  message: error.message,
+                  durationMs: timeoutMs,
+                })
+              )
+            )
+          },
+        })
+
+        // Cleanup on interrupt
+        return Effect.sync(() => {
+          clearTimeout(timeoutHandle)
+          pendingOks.delete(eventId)
+        })
+      })
+
+    const subscribe: RelayService["subscribe"] = (filters, subscriptionId) =>
+      Effect.gen(function* () {
+        if (state !== "connected") {
+          return yield* Effect.fail(
+            new ConnectionError({ message: "Not connected", url: config.url })
+          )
+        }
+
+        const subId = (subscriptionId ?? generateSubId()) as SubscriptionId
+        const queue = yield* Queue.unbounded<NostrEvent>()
+
+        const subState: SubscriptionState = {
+          id: subId,
+          filters: filters,
+          queue,
+          eoseReceived: false,
+        }
+
+        // Register subscription
+        subscriptions.set(subId, subState)
+
+        // Send REQ message
+        yield* sendMessage(["REQ", subId, ...filters])
+
+        // Create event stream from queue
+        const events = Stream.fromQueue(queue).pipe(
+          Stream.catchAll(() =>
+            Stream.fail(
+              new SubscriptionError({
+                message: "Subscription closed",
+                subscriptionId: subId,
+              })
+            )
+          )
+        )
+
+        // Unsubscribe function
+        const unsubscribe = (): Effect.Effect<void> =>
+          Effect.gen(function* () {
+            // Send CLOSE message
+            yield* sendMessage(["CLOSE", subId]).pipe(Effect.ignore)
+
+            // Remove from subscriptions
+            subscriptions.delete(subId)
+
+            // Shutdown queue
+            yield* Queue.shutdown(queue)
+          })
+
+        return {
+          id: subId,
+          events,
+          unsubscribe,
+        }
+      })
+
+    const connectionState: RelayService["connectionState"] = () =>
+      Effect.sync(() => state)
+
+    return {
+      _tag: "RelayService" as const,
+      url: config.url,
+      connectionState,
+      connect,
+      disconnect,
+      publish,
+      subscribe,
+      waitForOk,
+    }
+  })
+
+// =============================================================================
+// Layer Constructor
+// =============================================================================
+
+/**
+ * Create a RelayService layer for a specific relay URL
+ */
+export const makeRelayService = (config: RelayConnectionConfig): Layer.Layer<RelayService> =>
+  Layer.effect(RelayService, make(config))
+
+/**
+ * Create a RelayService scoped to the current scope
+ */
+export const makeRelayServiceScoped = (
+  config: RelayConnectionConfig
+): Effect.Effect<RelayService, never, never> =>
+  make(config).pipe(
+    Effect.tap((service) => service.connect().pipe(Effect.ignore))
+  )

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,0 +1,4 @@
+/**
+ * Client library exports
+ */
+export * from "./RelayService.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,5 +13,8 @@ export * from "./core/Nip19.js"
 export * from "./services/CryptoService.js"
 export * from "./services/EventService.js"
 
+// Client
+export * from "./client/index.js"
+
 // Relay
 export * from "./relay/index.js"

--- a/tsconfig.check.json
+++ b/tsconfig.check.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "lib": ["ESNext"],
+    "target": "ES2022",
+    "module": "Preserve",
+    "moduleDetection": "force",
+    "jsx": "react-jsx",
+    "allowJs": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "noEmit": true,
+    "types": ["bun"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "exactOptionalPropertyTypes": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary

- Implement `RelayService` for client-side WebSocket relay connections
- Add connection management with automatic reconnection using exponential backoff
- Support event subscriptions via `subscribe()` returning Effect Streams
- Support event publishing via `publish()` with OK response handling
- Use branded types for `Filter` and `SubscriptionId` for type safety
- Add `tsconfig.check.json` to work around @effect/language-service plugin compatibility issue

## Implementation Details

The RelayService provides:
- `connect()`/`disconnect()` - WebSocket lifecycle management
- `publish(event)` - Send events and wait for relay acknowledgment
- `subscribe(filters, subscriptionId?)` - Create subscriptions returning event streams
- `connectionState()` - Check current connection status
- `waitForOk(eventId)` - Wait for specific event acknowledgment

Uses plain JavaScript callbacks internally to bridge WebSocket events with Effect APIs.

## Test plan

- [x] `bun run verify` passes (typecheck + 122 tests)
- [x] Tests cover connection management
- [x] Tests cover event publishing with OK responses
- [x] Tests cover subscription creation/cleanup
- [x] Tests cover multiple concurrent subscriptions

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)