### PR TITLE
Client: NIP-65 relay list metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -171,6 +171,30 @@ After completing each issue:
 3. Move any completed issues from "Open Issues" to "Completed"
 4. Commit the BUILDOUT.md update to main
 
+## Nostr NIPs Reference
+
+**Local NIPs Repository:** The NIPs specification repo is cloned locally at `~/code/nips`. When implementing a NIP, read the spec from there instead of fetching from GitHub:
+
+```bash
+# Example: Read NIP-65 spec
+cat ~/code/nips/65.md
+```
+
+Common NIPs for this project:
+- `01.md` - Basic protocol flow (events, filters, subscriptions)
+- `02.md` - Follow list (kind 3)
+- `04.md` - Encrypted DMs (legacy)
+- `05.md` - DNS identifiers
+- `09.md` - Event deletion
+- `11.md` - Relay information
+- `16.md` - Event treatment (replaceable events)
+- `19.md` - bech32 encoding
+- `33.md` - Parameterized replaceable events
+- `42.md` - Authentication
+- `44.md` - Versioned encryption
+- `46.md` - Nostr Connect (remote signing)
+- `65.md` - Relay list metadata (kind 10002)
+
 <!-- effect-solutions:start -->
 ## Effect Solutions Usage
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Building both sides of the protocol in tandem - using each to test the other.
 - [x] EventService (create, verify)
 - [x] RelayService (WebSocket connection management)
 - [x] FollowListService (NIP-02 follow lists)
+- [x] RelayListService (NIP-65 relay list metadata)
 - [ ] RelayPool (multi-relay)
 
 ### Future
-NIP-05, NIP-44, NIP-65, NIP-46, DVMs
+NIP-05, NIP-44, NIP-46, DVMs

--- a/docs/BUILDOUT.md
+++ b/docs/BUILDOUT.md
@@ -31,7 +31,7 @@ src/
 - **Core**: Schema.ts (NIP-01 types), Errors.ts, Nip19.ts (bech32 encoding)
 - **Services**: CryptoService, EventService
 - **Relay**: EventStore, SubscriptionManager, MessageHandler, RelayServer, PolicyPipeline, NIP-16/33 Replaceable Events
-- **Client**: RelayService (WebSocket connection management), FollowListService (NIP-02)
+- **Client**: RelayService (WebSocket connection management), FollowListService (NIP-02), RelayListService (NIP-65)
 
 ### Open Issues
 
@@ -56,7 +56,7 @@ src/
 | #18 | NIP-05 identifier verification |
 | #19 | NIP-44 versioned encryption |
 | ~~#20~~ | ~~NIP-02 follow list management~~ ✅ |
-| #21 | NIP-65 relay list metadata |
+| ~~#21~~ | ~~NIP-65 relay list metadata~~ ✅ |
 | #22 | NIP-04 legacy DM encryption |
 | #23 | RelayPool multi-relay connections |
 | #24 | NIP-46 remote signing |
@@ -78,7 +78,7 @@ src/
 | Order | Relay | Client | Notes |
 |-------|-------|--------|-------|
 | 2.1 | ✅ #9: Replaceable | ✅ #20: NIP-02 Follow Lists | Client needs relay for kind 3 |
-| 2.2 | ✅ #9: Replaceable | #21: NIP-65 Relay Lists | Client needs relay for kind 10002 |
+| 2.2 | ✅ #9: Replaceable | ✅ #21: NIP-65 Relay Lists | Client needs relay for kind 10002 |
 | 2.3 | #8: NIP-11 Info | - | Client reads relay capabilities |
 | 2.4 | #10: NIP-22 | - | Timestamp bounds (policy exists) |
 | 2.5 | - | #18: NIP-05 | Independent (HTTP only) |

--- a/src/client/RelayListService.test.ts
+++ b/src/client/RelayListService.test.ts
@@ -1,0 +1,394 @@
+/**
+ * Tests for RelayListService (NIP-65)
+ */
+import { test, expect, describe, beforeAll, afterAll } from "bun:test"
+import { Effect, Layer } from "effect"
+import { RelayListService, RelayListServiceLive, type RelayEntry } from "./RelayListService.js"
+import { RelayService, makeRelayService } from "./RelayService.js"
+import { startTestRelay, type RelayHandle } from "../relay/index.js"
+import { CryptoService, CryptoServiceLive } from "../services/CryptoService.js"
+import { EventServiceLive } from "../services/EventService.js"
+
+describe("RelayListService", () => {
+  let relay: RelayHandle
+  let port: number
+
+  beforeAll(async () => {
+    port = 13000 + Math.floor(Math.random() * 10000)
+    relay = await startTestRelay(port)
+  })
+
+  afterAll(async () => {
+    await Effect.runPromise(relay.stop())
+  })
+
+  const makeTestLayers = () => {
+    const RelayLayer = makeRelayService({
+      url: `ws://localhost:${port}`,
+      reconnect: false,
+    })
+
+    const ServiceLayer = Layer.merge(
+      CryptoServiceLive,
+      EventServiceLive.pipe(Layer.provide(CryptoServiceLive))
+    )
+
+    return Layer.merge(
+      RelayLayer,
+      Layer.merge(
+        ServiceLayer,
+        RelayListServiceLive.pipe(
+          Layer.provide(RelayLayer),
+          Layer.provide(ServiceLayer)
+        )
+      )
+    )
+  }
+
+  describe("setRelayList and getRelayList", () => {
+    test("publishes and retrieves relay list", async () => {
+      const program = Effect.gen(function* () {
+        const relayService = yield* RelayService
+        const relayList = yield* RelayListService
+        const crypto = yield* CryptoService
+
+        yield* relayService.connect()
+
+        // Generate test keys
+        const privateKey = yield* crypto.generatePrivateKey()
+        const pubkey = yield* crypto.getPublicKey(privateKey)
+
+        const relays: RelayEntry[] = [
+          { url: "wss://relay1.example.com", mode: "both" },
+          { url: "wss://relay2.example.com", mode: "read" },
+          { url: "wss://relay3.example.com", mode: "write" },
+        ]
+
+        // Set relay list
+        const publishResult = yield* relayList.setRelayList(relays, privateKey)
+        expect(publishResult.accepted).toBe(true)
+
+        // Wait for event to be stored
+        yield* Effect.sleep(500)
+
+        // Get relay list back
+        const result = yield* relayList.getRelayList(pubkey)
+
+        expect(result.relays.length).toBe(3)
+        expect(result.relays[0]?.url).toBe("wss://relay1.example.com")
+        expect(result.relays[0]?.mode).toBe("both")
+        expect(result.relays[1]?.url).toBe("wss://relay2.example.com")
+        expect(result.relays[1]?.mode).toBe("read")
+        expect(result.relays[2]?.url).toBe("wss://relay3.example.com")
+        expect(result.relays[2]?.mode).toBe("write")
+        expect(result.event).toBeDefined()
+        expect(result.updatedAt).toBeDefined()
+
+        yield* relayService.disconnect()
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+
+    test("returns empty list for unknown pubkey", async () => {
+      const program = Effect.gen(function* () {
+        const relayService = yield* RelayService
+        const relayList = yield* RelayListService
+        const crypto = yield* CryptoService
+
+        yield* relayService.connect()
+
+        // Generate a key we won't use
+        const privateKey = yield* crypto.generatePrivateKey()
+        const unknownPubkey = yield* crypto.getPublicKey(privateKey)
+
+        const result = yield* relayList.getRelayList(unknownPubkey)
+
+        expect(result.relays.length).toBe(0)
+        expect(result.event).toBeUndefined()
+
+        yield* relayService.disconnect()
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+  })
+
+  describe("addRelay", () => {
+    test("adds a relay to empty list", async () => {
+      const program = Effect.gen(function* () {
+        const relayService = yield* RelayService
+        const relayList = yield* RelayListService
+        const crypto = yield* CryptoService
+
+        yield* relayService.connect()
+
+        const privateKey = yield* crypto.generatePrivateKey()
+        const pubkey = yield* crypto.getPublicKey(privateKey)
+
+        const newRelay: RelayEntry = {
+          url: "wss://new-relay.example.com",
+          mode: "both",
+        }
+
+        const result = yield* relayList.addRelay(newRelay, privateKey)
+        expect(result.accepted).toBe(true)
+
+        yield* Effect.sleep(500)
+
+        const { relays } = yield* relayList.getRelayList(pubkey)
+        expect(relays.length).toBe(1)
+        expect(relays[0]?.url).toBe(newRelay.url)
+
+        yield* relayService.disconnect()
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+
+    test("adds a relay to existing list", async () => {
+      const program = Effect.gen(function* () {
+        const relayService = yield* RelayService
+        const relayList = yield* RelayListService
+        const crypto = yield* CryptoService
+
+        yield* relayService.connect()
+
+        const privateKey = yield* crypto.generatePrivateKey()
+        const pubkey = yield* crypto.getPublicKey(privateKey)
+
+        // Set initial relay
+        const initialRelay: RelayEntry = {
+          url: "wss://initial-relay.example.com",
+          mode: "read",
+        }
+        yield* relayList.setRelayList([initialRelay], privateKey)
+        yield* Effect.sleep(1100) // Wait for different timestamp
+
+        // Add another relay
+        const newRelay: RelayEntry = {
+          url: "wss://new-relay.example.com",
+          mode: "write",
+        }
+        yield* relayList.addRelay(newRelay, privateKey)
+        yield* Effect.sleep(1100)
+
+        const { relays } = yield* relayList.getRelayList(pubkey)
+        expect(relays.length).toBe(2)
+
+        yield* relayService.disconnect()
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+
+    test("returns success for existing relay with same mode", async () => {
+      const program = Effect.gen(function* () {
+        const relayService = yield* RelayService
+        const relayList = yield* RelayListService
+        const crypto = yield* CryptoService
+
+        yield* relayService.connect()
+
+        const privateKey = yield* crypto.generatePrivateKey()
+
+        const relay: RelayEntry = {
+          url: "wss://existing-relay.example.com",
+          mode: "both",
+        }
+
+        // Add relay
+        yield* relayList.addRelay(relay, privateKey)
+        yield* Effect.sleep(1100)
+
+        // Try to add again with same mode
+        const result = yield* relayList.addRelay(relay, privateKey)
+        expect(result.accepted).toBe(true)
+        expect(result.message).toBe("relay already exists")
+
+        yield* relayService.disconnect()
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+
+    test("updates mode for existing relay", async () => {
+      const program = Effect.gen(function* () {
+        const relayService = yield* RelayService
+        const relayList = yield* RelayListService
+        const crypto = yield* CryptoService
+
+        yield* relayService.connect()
+
+        const privateKey = yield* crypto.generatePrivateKey()
+        const pubkey = yield* crypto.getPublicKey(privateKey)
+
+        // Add relay with read mode
+        const relayRead: RelayEntry = {
+          url: "wss://mode-change.example.com",
+          mode: "read",
+        }
+        yield* relayList.addRelay(relayRead, privateKey)
+        yield* Effect.sleep(1100)
+
+        // Update to write mode
+        const relayWrite: RelayEntry = {
+          url: "wss://mode-change.example.com",
+          mode: "write",
+        }
+        yield* relayList.addRelay(relayWrite, privateKey)
+        yield* Effect.sleep(1100)
+
+        const { relays } = yield* relayList.getRelayList(pubkey)
+        expect(relays.length).toBe(1)
+        expect(relays[0]?.mode).toBe("write")
+
+        yield* relayService.disconnect()
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+  })
+
+  describe("removeRelay", () => {
+    test("removes a relay from list", async () => {
+      const program = Effect.gen(function* () {
+        const relayService = yield* RelayService
+        const relayList = yield* RelayListService
+        const crypto = yield* CryptoService
+
+        yield* relayService.connect()
+
+        const privateKey = yield* crypto.generatePrivateKey()
+        const pubkey = yield* crypto.getPublicKey(privateKey)
+
+        // Set initial relays
+        yield* relayList.setRelayList(
+          [
+            { url: "wss://keep.example.com", mode: "both" },
+            { url: "wss://remove.example.com", mode: "read" },
+          ],
+          privateKey
+        )
+        yield* Effect.sleep(1100)
+
+        // Remove one
+        yield* relayList.removeRelay("wss://remove.example.com", privateKey)
+        yield* Effect.sleep(1100)
+
+        const { relays } = yield* relayList.getRelayList(pubkey)
+        expect(relays.length).toBe(1)
+        expect(relays[0]?.url).toBe("wss://keep.example.com")
+
+        yield* relayService.disconnect()
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+
+    test("returns success for non-existent relay", async () => {
+      const program = Effect.gen(function* () {
+        const relayService = yield* RelayService
+        const relayList = yield* RelayListService
+        const crypto = yield* CryptoService
+
+        yield* relayService.connect()
+
+        const privateKey = yield* crypto.generatePrivateKey()
+
+        const result = yield* relayList.removeRelay(
+          "wss://nonexistent.example.com",
+          privateKey
+        )
+
+        expect(result.accepted).toBe(true)
+        expect(result.message).toBe("relay not in list")
+
+        yield* relayService.disconnect()
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+  })
+
+  describe("getReadRelays and getWriteRelays", () => {
+    test("filters relays by mode", async () => {
+      const program = Effect.gen(function* () {
+        const relayService = yield* RelayService
+        const relayList = yield* RelayListService
+        const crypto = yield* CryptoService
+
+        yield* relayService.connect()
+
+        const privateKey = yield* crypto.generatePrivateKey()
+        const pubkey = yield* crypto.getPublicKey(privateKey)
+
+        yield* relayList.setRelayList(
+          [
+            { url: "wss://both.example.com", mode: "both" },
+            { url: "wss://read-only.example.com", mode: "read" },
+            { url: "wss://write-only.example.com", mode: "write" },
+          ],
+          privateKey
+        )
+        yield* Effect.sleep(500)
+
+        const readRelays = yield* relayList.getReadRelays(pubkey)
+        const writeRelays = yield* relayList.getWriteRelays(pubkey)
+
+        // Read relays: both + read-only
+        expect(readRelays.length).toBe(2)
+        expect(readRelays).toContain("wss://both.example.com")
+        expect(readRelays).toContain("wss://read-only.example.com")
+
+        // Write relays: both + write-only
+        expect(writeRelays.length).toBe(2)
+        expect(writeRelays).toContain("wss://both.example.com")
+        expect(writeRelays).toContain("wss://write-only.example.com")
+
+        yield* relayService.disconnect()
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+  })
+
+  describe("replaceable event semantics", () => {
+    test("newer relay list replaces older one", async () => {
+      const program = Effect.gen(function* () {
+        const relayService = yield* RelayService
+        const relayList = yield* RelayListService
+        const crypto = yield* CryptoService
+
+        yield* relayService.connect()
+
+        const privateKey = yield* crypto.generatePrivateKey()
+        const pubkey = yield* crypto.getPublicKey(privateKey)
+
+        // Set first relay list
+        yield* relayList.setRelayList(
+          [{ url: "wss://old.example.com", mode: "both" }],
+          privateKey
+        )
+        yield* Effect.sleep(1100) // Wait for different timestamp
+
+        // Set second relay list (should replace)
+        yield* relayList.setRelayList(
+          [{ url: "wss://new.example.com", mode: "read" }],
+          privateKey
+        )
+        yield* Effect.sleep(500)
+
+        // Query should return only the newer list
+        const { relays } = yield* relayList.getRelayList(pubkey)
+        expect(relays.length).toBe(1)
+        expect(relays[0]?.url).toBe("wss://new.example.com")
+        expect(relays[0]?.mode).toBe("read")
+
+        yield* relayService.disconnect()
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+  })
+})

--- a/src/client/RelayListService.ts
+++ b/src/client/RelayListService.ts
@@ -1,0 +1,334 @@
+/**
+ * RelayListService
+ *
+ * NIP-65 relay list metadata management service.
+ * Manages user's relay preferences as kind 10002 replaceable events.
+ *
+ * @see https://github.com/nostr-protocol/nips/blob/master/65.md
+ */
+import { Context, Effect, Layer, Option, Stream } from "effect"
+import { Schema } from "@effect/schema"
+import { RelayService, type PublishResult } from "./RelayService.js"
+import { EventService } from "../services/EventService.js"
+import { CryptoService } from "../services/CryptoService.js"
+import { RelayError } from "../core/Errors.js"
+import {
+  type NostrEvent,
+  type PublicKey,
+  type PrivateKey,
+  EventKind,
+  Filter,
+  Tag,
+} from "../core/Schema.js"
+
+// =============================================================================
+// Types
+// =============================================================================
+
+const decodeKind = Schema.decodeSync(EventKind)
+const decodeFilter = Schema.decodeSync(Filter)
+const decodeTag = Schema.decodeSync(Tag)
+
+/** Relay usage mode */
+export type RelayMode = "read" | "write" | "both"
+
+/** A single relay entry from a kind 10002 event */
+export interface RelayEntry {
+  /** The relay URL */
+  readonly url: string
+  /** Usage mode: read, write, or both (default) */
+  readonly mode: RelayMode
+}
+
+/** Result of a relay list query */
+export interface RelayListResult {
+  /** The list of relay entries */
+  readonly relays: readonly RelayEntry[]
+  /** The original event, if found */
+  readonly event?: NostrEvent
+  /** When the relay list was last updated */
+  readonly updatedAt?: number
+}
+
+// =============================================================================
+// Service Interface
+// =============================================================================
+
+export interface RelayListService {
+  readonly _tag: "RelayListService"
+
+  /**
+   * Get the relay list for a public key
+   * Queries the relay for kind 10002 events from the given author
+   */
+  getRelayList(pubkey: PublicKey): Effect.Effect<RelayListResult, RelayError>
+
+  /**
+   * Set the complete relay list for the current user
+   * Creates and publishes a new kind 10002 event, replacing any existing one
+   */
+  setRelayList(
+    relays: readonly RelayEntry[],
+    privateKey: PrivateKey
+  ): Effect.Effect<PublishResult, RelayError>
+
+  /**
+   * Add a relay to the current user's relay list
+   * Fetches current list, adds the new relay, and publishes updated list
+   */
+  addRelay(
+    relay: RelayEntry,
+    privateKey: PrivateKey
+  ): Effect.Effect<PublishResult, RelayError>
+
+  /**
+   * Remove a relay from the current user's relay list
+   * Fetches current list, removes the relay, and publishes updated list
+   */
+  removeRelay(
+    urlToRemove: string,
+    privateKey: PrivateKey
+  ): Effect.Effect<PublishResult, RelayError>
+
+  /**
+   * Get only read relays from the relay list
+   */
+  getReadRelays(pubkey: PublicKey): Effect.Effect<readonly string[], RelayError>
+
+  /**
+   * Get only write relays from the relay list
+   */
+  getWriteRelays(pubkey: PublicKey): Effect.Effect<readonly string[], RelayError>
+}
+
+// =============================================================================
+// Service Tag
+// =============================================================================
+
+export const RelayListService = Context.GenericTag<RelayListService>("RelayListService")
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/**
+ * Parse r-tags from a kind 10002 event into RelayEntry objects
+ */
+const parseRelaysFromEvent = (event: NostrEvent): readonly RelayEntry[] => {
+  const relays: RelayEntry[] = []
+
+  for (const tag of event.tags) {
+    if (tag[0] === "r" && tag.length >= 2) {
+      const url = tag[1]
+      if (!url || url.length === 0) continue
+
+      let mode: RelayMode = "both"
+      if (tag[2] === "read") {
+        mode = "read"
+      } else if (tag[2] === "write") {
+        mode = "write"
+      }
+
+      relays.push({ url, mode })
+    }
+  }
+
+  return relays
+}
+
+/**
+ * Convert RelayEntry objects to r-tags for a kind 10002 event
+ */
+const relaysToTags = (relays: readonly RelayEntry[]): typeof Tag.Type[] => {
+  return relays.map((relay) => {
+    const tagArray: string[] = ["r", relay.url]
+
+    // Only add marker if not "both" (default)
+    if (relay.mode !== "both") {
+      tagArray.push(relay.mode)
+    }
+
+    return decodeTag(tagArray)
+  })
+}
+
+// =============================================================================
+// Service Implementation
+// =============================================================================
+
+const make = Effect.gen(function* () {
+  const relay = yield* RelayService
+  const eventService = yield* EventService
+  const crypto = yield* CryptoService
+
+  const getRelayList: RelayListService["getRelayList"] = (pubkey) =>
+    Effect.gen(function* () {
+      // Create filter for kind 10002 from this author
+      const filter = decodeFilter({
+        kinds: [decodeKind(10002)],
+        authors: [pubkey],
+        limit: 1,
+      })
+
+      // Subscribe to get events
+      const sub = yield* relay.subscribe([filter])
+
+      // Race between collecting one event and a timeout
+      // For kind 10002 replaceable events, we expect 0 or 1 events
+      const maybeEventOption = yield* Effect.race(
+        sub.events.pipe(
+          Stream.runHead // Get just the first event (returns Option)
+        ),
+        Effect.sleep(500).pipe(Effect.as(Option.none<NostrEvent>()))
+      ).pipe(Effect.catchAll(() => Effect.succeed(Option.none<NostrEvent>())))
+
+      yield* sub.unsubscribe()
+
+      // If no event found, return empty list
+      if (Option.isNone(maybeEventOption)) {
+        return { relays: [] } as RelayListResult
+      }
+
+      const event = maybeEventOption.value
+      const relays = parseRelaysFromEvent(event)
+
+      return {
+        relays,
+        event,
+        updatedAt: event.created_at,
+      } as RelayListResult
+    }).pipe(
+      Effect.mapError(
+        (error) =>
+          new RelayError({
+            message: `Failed to get relay list: ${String(error)}`,
+            relay: relay.url,
+          })
+      )
+    )
+
+  const setRelayList: RelayListService["setRelayList"] = (relays, privateKey) =>
+    Effect.gen(function* () {
+      // Create kind 10002 event with r-tags
+      const tags = relaysToTags(relays)
+
+      const event = yield* eventService.createEvent(
+        {
+          kind: decodeKind(10002),
+          content: "", // NIP-65 specifies content should be empty
+          tags,
+        },
+        privateKey
+      )
+
+      // Publish to relay
+      return yield* relay.publish(event)
+    }).pipe(
+      Effect.mapError(
+        (error) =>
+          new RelayError({
+            message: `Failed to set relay list: ${String(error)}`,
+            relay: relay.url,
+          })
+      )
+    )
+
+  const addRelay: RelayListService["addRelay"] = (newRelay, privateKey) =>
+    Effect.gen(function* () {
+      // Get owner's public key
+      const ownerPubkey = yield* crypto.getPublicKey(privateKey)
+
+      // Get current relays
+      const { relays: currentRelays } = yield* getRelayList(ownerPubkey)
+
+      // Check if already exists (by URL)
+      const existingIndex = currentRelays.findIndex((r) => r.url === newRelay.url)
+      if (existingIndex !== -1) {
+        // Update mode if different, otherwise return success
+        const existing = currentRelays[existingIndex]!
+        if (existing.mode === newRelay.mode) {
+          return { accepted: true, message: "relay already exists" }
+        }
+        // Replace with new mode
+        const updatedRelays = currentRelays.map((r, i) =>
+          i === existingIndex ? newRelay : r
+        )
+        return yield* setRelayList(updatedRelays, privateKey)
+      }
+
+      // Add new relay and publish
+      const newRelays = [...currentRelays, newRelay]
+      return yield* setRelayList(newRelays, privateKey)
+    }).pipe(
+      Effect.mapError(
+        (error) =>
+          new RelayError({
+            message: `Failed to add relay: ${String(error)}`,
+            relay: relay.url,
+          })
+      )
+    )
+
+  const removeRelay: RelayListService["removeRelay"] = (urlToRemove, privateKey) =>
+    Effect.gen(function* () {
+      // Get owner's public key
+      const ownerPubkey = yield* crypto.getPublicKey(privateKey)
+
+      // Get current relays
+      const { relays: currentRelays } = yield* getRelayList(ownerPubkey)
+
+      // Remove the relay
+      const newRelays = currentRelays.filter((r) => r.url !== urlToRemove)
+
+      // If nothing changed, return success
+      if (newRelays.length === currentRelays.length) {
+        return { accepted: true, message: "relay not in list" }
+      }
+
+      return yield* setRelayList(newRelays, privateKey)
+    }).pipe(
+      Effect.mapError(
+        (error) =>
+          new RelayError({
+            message: `Failed to remove relay: ${String(error)}`,
+            relay: relay.url,
+          })
+      )
+    )
+
+  const getReadRelays: RelayListService["getReadRelays"] = (pubkey) =>
+    Effect.gen(function* () {
+      const { relays } = yield* getRelayList(pubkey)
+      return relays
+        .filter((r) => r.mode === "read" || r.mode === "both")
+        .map((r) => r.url)
+    })
+
+  const getWriteRelays: RelayListService["getWriteRelays"] = (pubkey) =>
+    Effect.gen(function* () {
+      const { relays } = yield* getRelayList(pubkey)
+      return relays
+        .filter((r) => r.mode === "write" || r.mode === "both")
+        .map((r) => r.url)
+    })
+
+  return {
+    _tag: "RelayListService" as const,
+    getRelayList,
+    setRelayList,
+    addRelay,
+    removeRelay,
+    getReadRelays,
+    getWriteRelays,
+  }
+})
+
+// =============================================================================
+// Service Layer
+// =============================================================================
+
+/**
+ * Live layer for RelayListService
+ * Requires RelayService, EventService, and CryptoService
+ */
+export const RelayListServiceLive = Layer.effect(RelayListService, make)

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -3,3 +3,4 @@
  */
 export * from "./RelayService.js"
 export * from "./FollowListService.js"
+export * from "./RelayListService.js"


### PR DESCRIPTION
## Summary
- Add `RelayListService` for managing relay preferences (kind 10002 replaceable events)
- Implement `getRelayList`, `setRelayList`, `addRelay`, `removeRelay`, `getReadRelays`, `getWriteRelays`
- Relay entries support URL and mode (read/write/both) per NIP-65 spec
- Add local NIPs repo reference to AGENTS.md (`~/code/nips`)

## Test plan
- [x] setRelayList publishes kind 10002 event and getRelayList retrieves it
- [x] Returns empty list for unknown pubkey
- [x] addRelay adds to empty list and existing list
- [x] addRelay returns success for existing relay with same mode
- [x] addRelay updates mode for existing relay
- [x] removeRelay removes from list and returns success for non-existent relay
- [x] getReadRelays filters to read + both modes
- [x] getWriteRelays filters to write + both modes
- [x] Newer relay list replaces older one (replaceable event semantics)

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)