### PR TITLE
Relay: NIP-11 Relay Information Document

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Building both sides of the protocol in tandem - using each to test the other.
 - [x] RelayServer (Bun.serve WebSocket)
 - [x] PolicyPipeline (composable event validation)
 - [x] NIP-16/33 Replaceable Events
+- [x] NIP-11 Relay Information Document
 - [ ] NIP module system
 
 ### Client

--- a/docs/BUILDOUT.md
+++ b/docs/BUILDOUT.md
@@ -30,7 +30,7 @@ src/
 ### Completed
 - **Core**: Schema.ts (NIP-01 types), Errors.ts, Nip19.ts (bech32 encoding)
 - **Services**: CryptoService, EventService
-- **Relay**: EventStore, SubscriptionManager, MessageHandler, RelayServer, PolicyPipeline, NIP-16/33 Replaceable Events
+- **Relay**: EventStore, SubscriptionManager, MessageHandler, RelayServer, PolicyPipeline, NIP-16/33 Replaceable Events, NIP-11 Relay Info
 - **Client**: RelayService (WebSocket connection management), FollowListService (NIP-02), RelayListService (NIP-65)
 
 ### Open Issues
@@ -41,7 +41,7 @@ src/
 | #5 | NIP Module system |
 | #6 | ConnectionManager |
 | #7 | NIP-09 Deletion |
-| #8 | NIP-11 Relay Info |
+| ~~#8~~ | ~~NIP-11 Relay Info~~ ✅ |
 | ~~#9~~ | ~~NIP-16/33 Replaceable Events~~ ✅ |
 | #10 | NIP-22 Timestamp Limits |
 | #11 | NIP-40 Expiration |
@@ -79,7 +79,7 @@ src/
 |-------|-------|--------|-------|
 | 2.1 | ✅ #9: Replaceable | ✅ #20: NIP-02 Follow Lists | Client needs relay for kind 3 |
 | 2.2 | ✅ #9: Replaceable | ✅ #21: NIP-65 Relay Lists | Client needs relay for kind 10002 |
-| 2.3 | #8: NIP-11 Info | - | Client reads relay capabilities |
+| 2.3 | ✅ #8: NIP-11 Info | - | Client reads relay capabilities |
 | 2.4 | #10: NIP-22 | - | Timestamp bounds (policy exists) |
 | 2.5 | - | #18: NIP-05 | Independent (HTTP only) |
 

--- a/src/relay/RelayInfo.test.ts
+++ b/src/relay/RelayInfo.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Tests for RelayInfo (NIP-11)
+ */
+import { test, expect, describe, beforeAll, afterAll } from "bun:test"
+import { Effect } from "effect"
+import {
+  defaultRelayInfo,
+  mergeRelayInfo,
+  type RelayInfo,
+} from "./RelayInfo.js"
+import { startTestRelay, startRelay, type RelayHandle } from "./index.js"
+
+describe("RelayInfo", () => {
+  describe("defaultRelayInfo", () => {
+    test("has required fields", () => {
+      expect(defaultRelayInfo.name).toBe("nostr-effect relay")
+      expect(defaultRelayInfo.description).toBeDefined()
+      expect(defaultRelayInfo.supported_nips).toContain(1)
+      expect(defaultRelayInfo.supported_nips).toContain(11)
+      expect(defaultRelayInfo.software).toBeDefined()
+      expect(defaultRelayInfo.version).toBeDefined()
+    })
+  })
+
+  describe("mergeRelayInfo", () => {
+    test("uses defaults when no custom provided", () => {
+      const result = mergeRelayInfo({})
+      expect(result.name).toBe("nostr-effect relay")
+      expect(result.supported_nips).toEqual([1, 11, 16, 33])
+    })
+
+    test("overrides defaults with custom values", () => {
+      const custom: Partial<RelayInfo> = {
+        name: "My Custom Relay",
+        description: "A custom relay description",
+      }
+      const result = mergeRelayInfo(custom)
+      expect(result.name).toBe("My Custom Relay")
+      expect(result.description).toBe("A custom relay description")
+      // Keeps other defaults
+      expect(result.supported_nips).toEqual([1, 11, 16, 33])
+    })
+
+    test("merges limitation objects", () => {
+      const custom: Partial<RelayInfo> = {
+        limitation: {
+          max_message_length: 65536,
+          auth_required: true,
+        },
+      }
+      const result = mergeRelayInfo(custom)
+      expect(result.limitation?.max_message_length).toBe(65536)
+      expect(result.limitation?.auth_required).toBe(true)
+    })
+  })
+})
+
+describe("NIP-11 HTTP endpoint", () => {
+  let relay: RelayHandle
+  let port: number
+
+  beforeAll(async () => {
+    port = 14000 + Math.floor(Math.random() * 10000)
+    relay = await startTestRelay(port)
+  })
+
+  afterAll(async () => {
+    await Effect.runPromise(relay.stop())
+  })
+
+  test("returns relay info with Accept: application/nostr+json", async () => {
+    const response = await fetch(`http://localhost:${port}/`, {
+      headers: {
+        Accept: "application/nostr+json",
+      },
+    })
+
+    expect(response.ok).toBe(true)
+    expect(response.headers.get("Content-Type")).toBe("application/nostr+json")
+
+    const info = (await response.json()) as RelayInfo
+    expect(info.name).toBe("nostr-effect relay")
+    expect(info.supported_nips).toContain(1)
+    expect(info.supported_nips).toContain(11)
+  })
+
+  test("includes CORS headers", async () => {
+    const response = await fetch(`http://localhost:${port}/`, {
+      headers: {
+        Accept: "application/nostr+json",
+      },
+    })
+
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*")
+    expect(response.headers.get("Access-Control-Allow-Methods")).toContain("GET")
+  })
+
+  test("handles CORS preflight request", async () => {
+    const response = await fetch(`http://localhost:${port}/`, {
+      method: "OPTIONS",
+    })
+
+    expect(response.status).toBe(204)
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*")
+    expect(response.headers.get("Access-Control-Allow-Headers")).toContain("Accept")
+    expect(response.headers.get("Access-Control-Allow-Methods")).toContain("GET")
+  })
+})
+
+describe("NIP-11 with custom config", () => {
+  let relay: RelayHandle
+  let port: number
+
+  beforeAll(async () => {
+    port = 15000 + Math.floor(Math.random() * 10000)
+    relay = await startRelay({
+      port,
+      relayInfo: {
+        name: "Custom Test Relay",
+        description: "Testing custom relay info",
+        pubkey: "0000000000000000000000000000000000000000000000000000000000000001",
+        supported_nips: [1, 11, 16, 33, 42],
+        limitation: {
+          max_subscriptions: 100,
+          auth_required: false,
+        },
+      },
+    })
+  })
+
+  afterAll(async () => {
+    await Effect.runPromise(relay.stop())
+  })
+
+  test("returns custom relay info", async () => {
+    const response = await fetch(`http://localhost:${port}/`, {
+      headers: {
+        Accept: "application/nostr+json",
+      },
+    })
+
+    const info = (await response.json()) as RelayInfo
+    expect(info.name).toBe("Custom Test Relay")
+    expect(info.description).toBe("Testing custom relay info")
+    expect(info.pubkey).toBe("0000000000000000000000000000000000000000000000000000000000000001")
+    expect(info.supported_nips).toContain(42)
+  })
+
+  test("returns merged limitation settings", async () => {
+    const response = await fetch(`http://localhost:${port}/`, {
+      headers: {
+        Accept: "application/nostr+json",
+      },
+    })
+
+    const info = (await response.json()) as RelayInfo
+    expect(info.limitation?.max_subscriptions).toBe(100)
+    expect(info.limitation?.auth_required).toBe(false)
+  })
+})

--- a/src/relay/RelayInfo.ts
+++ b/src/relay/RelayInfo.ts
@@ -1,0 +1,180 @@
+/**
+ * RelayInfo
+ *
+ * NIP-11 Relay Information Document schema and types.
+ * Describes relay metadata served at the WebSocket endpoint.
+ *
+ * @see https://github.com/nostr-protocol/nips/blob/master/11.md
+ */
+import { Schema } from "@effect/schema"
+
+// =============================================================================
+// Limitation Schema
+// =============================================================================
+
+/**
+ * Server limitations imposed by the relay
+ */
+export const RelayLimitation = Schema.Struct({
+  /** Maximum bytes for incoming JSON messages */
+  max_message_length: Schema.optional(Schema.Number),
+  /** Maximum active subscriptions per connection */
+  max_subscriptions: Schema.optional(Schema.Number),
+  /** Maximum limit value in subscription filters */
+  max_limit: Schema.optional(Schema.Number),
+  /** Maximum length of subscription ID */
+  max_subid_length: Schema.optional(Schema.Number),
+  /** Maximum number of tags per event */
+  max_event_tags: Schema.optional(Schema.Number),
+  /** Maximum characters in event content */
+  max_content_length: Schema.optional(Schema.Number),
+  /** Minimum PoW difficulty required (NIP-13) */
+  min_pow_difficulty: Schema.optional(Schema.Number),
+  /** Whether NIP-42 auth is required before any action */
+  auth_required: Schema.optional(Schema.Boolean),
+  /** Whether payment is required */
+  payment_required: Schema.optional(Schema.Boolean),
+  /** Whether writes are restricted */
+  restricted_writes: Schema.optional(Schema.Boolean),
+  /** Lower limit for created_at (seconds in past) */
+  created_at_lower_limit: Schema.optional(Schema.Number),
+  /** Upper limit for created_at (seconds in future) */
+  created_at_upper_limit: Schema.optional(Schema.Number),
+  /** Default limit if not specified in filter */
+  default_limit: Schema.optional(Schema.Number),
+})
+
+export type RelayLimitation = Schema.Schema.Type<typeof RelayLimitation>
+
+// =============================================================================
+// Fee Schema
+// =============================================================================
+
+export const FeeAmount = Schema.Struct({
+  amount: Schema.Number,
+  unit: Schema.String,
+  period: Schema.optional(Schema.Number),
+})
+
+export const RelayFees = Schema.Struct({
+  admission: Schema.optional(Schema.Array(FeeAmount)),
+  subscription: Schema.optional(Schema.Array(FeeAmount)),
+  publication: Schema.optional(
+    Schema.Array(
+      Schema.Struct({
+        kinds: Schema.optional(Schema.Array(Schema.Number)),
+        amount: Schema.Number,
+        unit: Schema.String,
+      })
+    )
+  ),
+})
+
+export type RelayFees = Schema.Schema.Type<typeof RelayFees>
+
+// =============================================================================
+// Retention Schema
+// =============================================================================
+
+export const RetentionSpec = Schema.Struct({
+  /** Kind numbers or ranges [start, end] */
+  kinds: Schema.optional(
+    Schema.Array(Schema.Union(Schema.Number, Schema.Tuple(Schema.Number, Schema.Number)))
+  ),
+  /** Time in seconds to retain (null = infinity) */
+  time: Schema.optional(Schema.NullOr(Schema.Number)),
+  /** Maximum count to retain */
+  count: Schema.optional(Schema.Number),
+})
+
+export type RetentionSpec = Schema.Schema.Type<typeof RetentionSpec>
+
+// =============================================================================
+// Main RelayInfo Schema
+// =============================================================================
+
+/**
+ * NIP-11 Relay Information Document
+ */
+export const RelayInfo = Schema.Struct({
+  // Basic info
+  /** Relay name (< 30 chars recommended) */
+  name: Schema.optional(Schema.String),
+  /** Detailed relay description */
+  description: Schema.optional(Schema.String),
+  /** Banner image URL */
+  banner: Schema.optional(Schema.String),
+  /** Icon image URL */
+  icon: Schema.optional(Schema.String),
+  /** Admin contact pubkey (32-byte hex) */
+  pubkey: Schema.optional(Schema.String),
+  /** Relay's own pubkey (32-byte hex) */
+  self: Schema.optional(Schema.String),
+  /** Alternative contact (URI) */
+  contact: Schema.optional(Schema.String),
+  /** List of supported NIP numbers */
+  supported_nips: Schema.optional(Schema.Array(Schema.Number)),
+  /** Relay software URL */
+  software: Schema.optional(Schema.String),
+  /** Software version string */
+  version: Schema.optional(Schema.String),
+  /** Privacy policy URL */
+  privacy_policy: Schema.optional(Schema.String),
+  /** Terms of service URL */
+  terms_of_service: Schema.optional(Schema.String),
+
+  // Extra fields
+  /** Server limitations */
+  limitation: Schema.optional(RelayLimitation),
+  /** Event retention policies */
+  retention: Schema.optional(Schema.Array(RetentionSpec)),
+  /** Countries whose laws may apply */
+  relay_countries: Schema.optional(Schema.Array(Schema.String)),
+  /** Supported languages (IETF tags) */
+  language_tags: Schema.optional(Schema.Array(Schema.String)),
+  /** Topic/content tags */
+  tags: Schema.optional(Schema.Array(Schema.String)),
+  /** Posting policy URL */
+  posting_policy: Schema.optional(Schema.String),
+  /** Payments URL */
+  payments_url: Schema.optional(Schema.String),
+  /** Fee schedules */
+  fees: Schema.optional(RelayFees),
+})
+
+export type RelayInfo = Schema.Schema.Type<typeof RelayInfo>
+
+// =============================================================================
+// Default Info
+// =============================================================================
+
+/**
+ * Default relay info for nostr-effect
+ */
+export const defaultRelayInfo: RelayInfo = {
+  name: "nostr-effect relay",
+  description: "Effect-based Nostr relay implementation",
+  supported_nips: [1, 11, 16, 33],
+  software: "https://github.com/OpenAgentsInc/nostr-effect",
+  version: "0.1.0",
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * Merge partial relay info with defaults
+ */
+export const mergeRelayInfo = (
+  custom: Partial<RelayInfo>,
+  defaults: RelayInfo = defaultRelayInfo
+): RelayInfo => ({
+  ...defaults,
+  ...custom,
+  // Merge nested objects properly
+  limitation: custom.limitation
+    ? { ...defaults.limitation, ...custom.limitation }
+    : defaults.limitation,
+  fees: custom.fees ? { ...defaults.fees, ...custom.fees } : defaults.fees,
+})

--- a/src/relay/RelayServer.test.ts
+++ b/src/relay/RelayServer.test.ts
@@ -291,7 +291,8 @@ describe("RelayServer", () => {
 
       const info = (await response.json()) as { supported_nips: number[]; software: string }
       expect(info.supported_nips).toContain(1)
-      expect(info.software).toBe("nostr-effect")
+      expect(info.supported_nips).toContain(11)
+      expect(info.software).toContain("nostr-effect")
     })
   })
 

--- a/src/relay/index.ts
+++ b/src/relay/index.ts
@@ -47,6 +47,16 @@ export {
   type ConnectionData,
 } from "./RelayServer.js"
 
+// NIP-11 Relay Info
+export {
+  RelayInfo,
+  RelayLimitation,
+  RelayFees,
+  defaultRelayInfo,
+  mergeRelayInfo,
+  type RetentionSpec,
+} from "./RelayInfo.js"
+
 // Policy module
 export * from "./policy/index.js"
 


### PR DESCRIPTION
## Summary
- Add `RelayInfo` schema with all NIP-11 fields (name, description, supported_nips, limitation, fees, retention, etc.)
- Make relay info configurable via `relayInfo` option in `RelayConfig`
- Return JSON at HTTP endpoint when `Accept: application/nostr+json` header is sent
- Add CORS headers and preflight OPTIONS request handling
- Default relay info includes supported NIPs: 1, 11, 16, 33

## Test plan
- [x] defaultRelayInfo has required fields
- [x] mergeRelayInfo uses defaults when no custom provided
- [x] mergeRelayInfo overrides defaults with custom values
- [x] mergeRelayInfo merges limitation objects
- [x] HTTP endpoint returns relay info with Accept header
- [x] Includes CORS headers in response
- [x] Handles CORS preflight OPTIONS request
- [x] Custom relay config returns custom info

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)