### PR TITLE
Services: NIP-44 versioned encryption

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "dependencies": {
         "@effect/platform": "0.93.5",
         "@effect/schema": "0.75.5",
+        "@noble/ciphers": "1.2.1",
         "@noble/curves": "1.8.1",
         "@noble/hashes": "1.7.1",
         "@scure/base": "1.2.4",
@@ -36,6 +37,8 @@
     "@msgpackr-extract/msgpackr-extract-linux-x64": ["@msgpackr-extract/msgpackr-extract-linux-x64@3.0.3", "", { "os": "linux", "cpu": "x64" }, "sha512-cvwNfbP07pKUfq1uH+S6KJ7dT9K8WOE4ZiAcsrSes+UY55E/0jLYc+vq+DO7jlmqRb5zAggExKm0H7O/CBaesg=="],
 
     "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3", "", { "os": "win32", "cpu": "x64" }, "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ=="],
+
+    "@noble/ciphers": ["@noble/ciphers@1.2.1", "", {}, "sha512-rONPWMC7PeExE077uLE4oqWrZ1IvAfz3oH9LibVAcVCopJiA9R62uavnbEzdkVmJYI6M6Zgkbeb07+tWjlq2XA=="],
 
     "@noble/curves": ["@noble/curves@1.8.1", "", { "dependencies": { "@noble/hashes": "1.7.1" } }, "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ=="],
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@effect/platform": "0.93.5",
     "@effect/schema": "0.75.5",
+    "@noble/ciphers": "1.2.1",
     "@noble/curves": "1.8.1",
     "@noble/hashes": "1.7.1",
     "@scure/base": "1.2.4",

--- a/src/core/Errors.ts
+++ b/src/core/Errors.ts
@@ -37,7 +37,16 @@ export class CryptoError extends Schema.TaggedError<CryptoError>()(
   "CryptoError",
   {
     message: Schema.String,
-    operation: Schema.Literal("sign", "verify", "hash", "generateKey"),
+    operation: Schema.Literal(
+      "sign",
+      "verify",
+      "hash",
+      "generateKey",
+      "encrypt",
+      "decrypt",
+      "getConversationKey",
+      "encryptWithNonce"
+    ),
   }
 ) {}
 

--- a/src/services/Nip44Service.test.ts
+++ b/src/services/Nip44Service.test.ts
@@ -1,0 +1,386 @@
+/**
+ * Tests for Nip44Service (NIP-44 encryption)
+ */
+import { test, expect, describe } from "bun:test"
+import { Effect, Layer } from "effect"
+import {
+  Nip44Service,
+  Nip44ServiceLive,
+  type ConversationKey,
+  type EncryptedPayload,
+} from "./Nip44Service.js"
+import { CryptoService, CryptoServiceLive } from "./CryptoService.js"
+import type { PrivateKey, PublicKey } from "../core/Schema.js"
+import { hexToBytes } from "@noble/hashes/utils"
+
+describe("Nip44Service", () => {
+  const makeTestLayers = () => {
+    return Layer.merge(CryptoServiceLive, Nip44ServiceLive)
+  }
+
+  describe("getConversationKey", () => {
+    test("derives conversation key from private and public key", async () => {
+      const program = Effect.gen(function* () {
+        const nip44 = yield* Nip44Service
+        const crypto = yield* CryptoService
+
+        const privateKey1 = yield* crypto.generatePrivateKey()
+        const publicKey1 = yield* crypto.getPublicKey(privateKey1)
+        const privateKey2 = yield* crypto.generatePrivateKey()
+        const publicKey2 = yield* crypto.getPublicKey(privateKey2)
+
+        // conv(a, B) should equal conv(b, A)
+        const convKey1 = yield* nip44.getConversationKey(privateKey1, publicKey2)
+        const convKey2 = yield* nip44.getConversationKey(privateKey2, publicKey1)
+
+        expect(convKey1).toBe(convKey2)
+        expect(convKey1.length).toBe(64) // 32 bytes = 64 hex chars
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+
+    test("produces different keys for different key pairs", async () => {
+      const program = Effect.gen(function* () {
+        const nip44 = yield* Nip44Service
+        const crypto = yield* CryptoService
+
+        const privateKey1 = yield* crypto.generatePrivateKey()
+        const privateKey2 = yield* crypto.generatePrivateKey()
+        const publicKey2 = yield* crypto.getPublicKey(privateKey2)
+        const privateKey3 = yield* crypto.generatePrivateKey()
+        const publicKey3 = yield* crypto.getPublicKey(privateKey3)
+
+        const convKey12 = yield* nip44.getConversationKey(privateKey1, publicKey2)
+        const convKey13 = yield* nip44.getConversationKey(privateKey1, publicKey3)
+
+        expect(convKey12).not.toBe(convKey13)
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+
+    // Test vector from NIP-44 spec
+    test("matches test vector from NIP-44 spec", async () => {
+      const program = Effect.gen(function* () {
+        const nip44 = yield* Nip44Service
+
+        // Test vector from nip44.vectors.json
+        const sec1 =
+          "0000000000000000000000000000000000000000000000000000000000000001" as PrivateKey
+
+        // Derive public keys manually for test vectors
+        // pub2 for sec2 = 02c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5
+        // But schnorr pubkeys are x-only, so just x coordinate
+        const pub2 =
+          "c6047f9441ed7d6d3045406e95c07cd85c778e4b8cef3ca7abac09b95c709ee5" as PublicKey
+
+        const convKey = yield* nip44.getConversationKey(sec1, pub2)
+
+        // Expected from test vector
+        expect(convKey as string).toBe(
+          "c41c775356fd92eadc63ff5a0dc1da211b268cbea22316767095b2871ea1412d"
+        )
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+  })
+
+  describe("encrypt and decrypt", () => {
+    test("encrypts and decrypts a message", async () => {
+      const program = Effect.gen(function* () {
+        const nip44 = yield* Nip44Service
+        const crypto = yield* CryptoService
+
+        const privateKey1 = yield* crypto.generatePrivateKey()
+        const privateKey2 = yield* crypto.generatePrivateKey()
+        const publicKey2 = yield* crypto.getPublicKey(privateKey2)
+
+        const convKey = yield* nip44.getConversationKey(privateKey1, publicKey2)
+
+        const plaintext = "Hello, NIP-44!"
+        const encrypted = yield* nip44.encrypt(plaintext, convKey)
+
+        // Encrypted payload should be base64
+        expect(encrypted.length).toBeGreaterThan(0)
+
+        // Decrypt with same conversation key
+        const decrypted = yield* nip44.decrypt(encrypted, convKey)
+        expect(decrypted).toBe(plaintext)
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+
+    test("encrypts and decrypts long messages", async () => {
+      const program = Effect.gen(function* () {
+        const nip44 = yield* Nip44Service
+        const crypto = yield* CryptoService
+
+        const privateKey1 = yield* crypto.generatePrivateKey()
+        const publicKey2 = yield* crypto.getPublicKey(yield* crypto.generatePrivateKey())
+
+        const convKey = yield* nip44.getConversationKey(privateKey1, publicKey2)
+
+        // Test with a longer message
+        const plaintext = "A".repeat(1000)
+        const encrypted = yield* nip44.encrypt(plaintext, convKey)
+        const decrypted = yield* nip44.decrypt(encrypted, convKey)
+
+        expect(decrypted).toBe(plaintext)
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+
+    test("encrypts and decrypts unicode messages", async () => {
+      const program = Effect.gen(function* () {
+        const nip44 = yield* Nip44Service
+        const crypto = yield* CryptoService
+
+        const privateKey1 = yield* crypto.generatePrivateKey()
+        const publicKey2 = yield* crypto.getPublicKey(yield* crypto.generatePrivateKey())
+
+        const convKey = yield* nip44.getConversationKey(privateKey1, publicKey2)
+
+        const plaintext = "Hello 🌍! こんにちは 世界!"
+        const encrypted = yield* nip44.encrypt(plaintext, convKey)
+        const decrypted = yield* nip44.decrypt(encrypted, convKey)
+
+        expect(decrypted).toBe(plaintext)
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+
+    test("produces different ciphertext for same plaintext (random nonce)", async () => {
+      const program = Effect.gen(function* () {
+        const nip44 = yield* Nip44Service
+        const crypto = yield* CryptoService
+
+        const privateKey1 = yield* crypto.generatePrivateKey()
+        const publicKey2 = yield* crypto.getPublicKey(yield* crypto.generatePrivateKey())
+
+        const convKey = yield* nip44.getConversationKey(privateKey1, publicKey2)
+
+        const plaintext = "Same message"
+        const encrypted1 = yield* nip44.encrypt(plaintext, convKey)
+        const encrypted2 = yield* nip44.encrypt(plaintext, convKey)
+
+        // Different nonces should produce different ciphertexts
+        expect(encrypted1).not.toBe(encrypted2)
+
+        // But both should decrypt to the same plaintext
+        const decrypted1 = yield* nip44.decrypt(encrypted1, convKey)
+        const decrypted2 = yield* nip44.decrypt(encrypted2, convKey)
+        expect(decrypted1).toBe(plaintext)
+        expect(decrypted2).toBe(plaintext)
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+
+    // Test vector from NIP-44 spec
+    test("matches test vector from NIP-44 spec", async () => {
+      const program = Effect.gen(function* () {
+        const nip44 = yield* Nip44Service
+
+        const convKey =
+          "c41c775356fd92eadc63ff5a0dc1da211b268cbea22316767095b2871ea1412d" as ConversationKey
+        const nonce = hexToBytes(
+          "0000000000000000000000000000000000000000000000000000000000000001"
+        )
+        const plaintext = "a"
+        const expectedPayload =
+          "AgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABee0G5VSK0/9YypIObAtDKfYEAjD35uVkHyB0F4DwrcNaCXlCWZKaArsGrY6M9wnuTMxWfp1RTN9Xga8no+kF5Vsb"
+
+        const encrypted = yield* nip44.encryptWithNonce(plaintext, convKey, nonce)
+        expect(encrypted as string).toBe(expectedPayload)
+
+        const decrypted = yield* nip44.decrypt(encrypted, convKey)
+        expect(decrypted).toBe(plaintext)
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+  })
+
+  describe("decrypt error handling", () => {
+    test("fails on invalid MAC", async () => {
+      const program = Effect.gen(function* () {
+        const nip44 = yield* Nip44Service
+        const crypto = yield* CryptoService
+
+        const privateKey1 = yield* crypto.generatePrivateKey()
+        const publicKey2 = yield* crypto.getPublicKey(yield* crypto.generatePrivateKey())
+
+        const convKey = yield* nip44.getConversationKey(privateKey1, publicKey2)
+        const encrypted = yield* nip44.encrypt("test message", convKey)
+
+        // Tamper with the payload (change last character)
+        const tampered = (encrypted.slice(0, -1) +
+          (encrypted.slice(-1) === "A" ? "B" : "A")) as EncryptedPayload
+
+        const result = yield* nip44.decrypt(tampered, convKey).pipe(Effect.either)
+
+        expect(result._tag).toBe("Left")
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+
+    test("fails on wrong conversation key", async () => {
+      const program = Effect.gen(function* () {
+        const nip44 = yield* Nip44Service
+        const crypto = yield* CryptoService
+
+        const privateKey1 = yield* crypto.generatePrivateKey()
+        const publicKey2 = yield* crypto.getPublicKey(yield* crypto.generatePrivateKey())
+        const privateKey3 = yield* crypto.generatePrivateKey()
+        const publicKey4 = yield* crypto.getPublicKey(yield* crypto.generatePrivateKey())
+
+        const convKey1 = yield* nip44.getConversationKey(privateKey1, publicKey2)
+        const convKey2 = yield* nip44.getConversationKey(privateKey3, publicKey4)
+
+        const encrypted = yield* nip44.encrypt("test message", convKey1)
+
+        // Try to decrypt with wrong key
+        const result = yield* nip44.decrypt(encrypted, convKey2).pipe(Effect.either)
+
+        expect(result._tag).toBe("Left")
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+
+    test("fails on empty payload", async () => {
+      const program = Effect.gen(function* () {
+        const nip44 = yield* Nip44Service
+        const crypto = yield* CryptoService
+
+        const privateKey1 = yield* crypto.generatePrivateKey()
+        const publicKey2 = yield* crypto.getPublicKey(yield* crypto.generatePrivateKey())
+
+        const convKey = yield* nip44.getConversationKey(privateKey1, publicKey2)
+
+        const result = yield* nip44
+          .decrypt("" as EncryptedPayload, convKey)
+          .pipe(Effect.either)
+
+        expect(result._tag).toBe("Left")
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+
+    test("fails on unknown version", async () => {
+      const program = Effect.gen(function* () {
+        const nip44 = yield* Nip44Service
+        const crypto = yield* CryptoService
+
+        const privateKey1 = yield* crypto.generatePrivateKey()
+        const publicKey2 = yield* crypto.getPublicKey(yield* crypto.generatePrivateKey())
+
+        const convKey = yield* nip44.getConversationKey(privateKey1, publicKey2)
+
+        // Payload starting with # indicates unsupported version
+        const result = yield* nip44
+          .decrypt("#invalid" as unknown as EncryptedPayload, convKey)
+          .pipe(Effect.either)
+
+        expect(result._tag).toBe("Left")
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+  })
+
+  describe("padding", () => {
+    test("handles minimum plaintext size (1 byte)", async () => {
+      const program = Effect.gen(function* () {
+        const nip44 = yield* Nip44Service
+        const crypto = yield* CryptoService
+
+        const privateKey1 = yield* crypto.generatePrivateKey()
+        const publicKey2 = yield* crypto.getPublicKey(yield* crypto.generatePrivateKey())
+
+        const convKey = yield* nip44.getConversationKey(privateKey1, publicKey2)
+
+        const plaintext = "a"
+        const encrypted = yield* nip44.encrypt(plaintext, convKey)
+        const decrypted = yield* nip44.decrypt(encrypted, convKey)
+
+        expect(decrypted).toBe(plaintext)
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+
+    test("handles various message sizes correctly", async () => {
+      const program = Effect.gen(function* () {
+        const nip44 = yield* Nip44Service
+        const crypto = yield* CryptoService
+
+        const privateKey1 = yield* crypto.generatePrivateKey()
+        const publicKey2 = yield* crypto.getPublicKey(yield* crypto.generatePrivateKey())
+
+        const convKey = yield* nip44.getConversationKey(privateKey1, publicKey2)
+
+        // Test various sizes
+        for (const size of [1, 15, 16, 31, 32, 33, 64, 100, 255, 256, 500]) {
+          const plaintext = "x".repeat(size)
+          const encrypted = yield* nip44.encrypt(plaintext, convKey)
+          const decrypted = yield* nip44.decrypt(encrypted, convKey)
+          expect(decrypted).toBe(plaintext)
+        }
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+  })
+
+  describe("bidirectional communication", () => {
+    test("allows two parties to encrypt/decrypt to each other", async () => {
+      const program = Effect.gen(function* () {
+        const nip44 = yield* Nip44Service
+        const crypto = yield* CryptoService
+
+        // Alice
+        const alicePriv = yield* crypto.generatePrivateKey()
+        const alicePub = yield* crypto.getPublicKey(alicePriv)
+
+        // Bob
+        const bobPriv = yield* crypto.generatePrivateKey()
+        const bobPub = yield* crypto.getPublicKey(bobPriv)
+
+        // Alice derives conversation key using her private and Bob's public
+        const aliceConvKey = yield* nip44.getConversationKey(alicePriv, bobPub)
+
+        // Bob derives conversation key using his private and Alice's public
+        const bobConvKey = yield* nip44.getConversationKey(bobPriv, alicePub)
+
+        // Both should have the same conversation key
+        expect(aliceConvKey).toBe(bobConvKey)
+
+        // Alice encrypts a message
+        const aliceMessage = "Hello Bob!"
+        const aliceEncrypted = yield* nip44.encrypt(aliceMessage, aliceConvKey)
+
+        // Bob decrypts Alice's message
+        const bobDecrypted = yield* nip44.decrypt(aliceEncrypted, bobConvKey)
+        expect(bobDecrypted).toBe(aliceMessage)
+
+        // Bob encrypts a reply
+        const bobMessage = "Hi Alice!"
+        const bobEncrypted = yield* nip44.encrypt(bobMessage, bobConvKey)
+
+        // Alice decrypts Bob's reply
+        const aliceDecrypted = yield* nip44.decrypt(bobEncrypted, aliceConvKey)
+        expect(aliceDecrypted).toBe(bobMessage)
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+  })
+})

--- a/src/services/Nip44Service.ts
+++ b/src/services/Nip44Service.ts
@@ -1,0 +1,380 @@
+/**
+ * Nip44Service
+ *
+ * NIP-44 versioned encryption for Nostr.
+ * Implements secp256k1 ECDH, HKDF, ChaCha20, HMAC-SHA256, and custom padding.
+ *
+ * @see https://github.com/nostr-protocol/nips/blob/master/44.md
+ */
+import { Context, Effect, Layer } from "effect"
+import { secp256k1 } from "@noble/curves/secp256k1"
+import { extract, expand } from "@noble/hashes/hkdf"
+import { sha256 } from "@noble/hashes/sha256"
+import { hmac } from "@noble/hashes/hmac"
+import { chacha20 } from "@noble/ciphers/chacha"
+import { randomBytes } from "@noble/hashes/utils"
+import { bytesToHex, hexToBytes } from "@noble/hashes/utils"
+import { CryptoError } from "../core/Errors.js"
+import type { PrivateKey, PublicKey } from "../core/Schema.js"
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/** Conversation key (32 bytes hex) derived from ECDH + HKDF */
+export type ConversationKey = string & { readonly _brand: "ConversationKey" }
+
+/** NIP-44 encrypted payload (base64 encoded) */
+export type EncryptedPayload = string & { readonly _brand: "EncryptedPayload" }
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const MIN_PLAINTEXT_SIZE = 1
+const MAX_PLAINTEXT_SIZE = 65535
+const SALT = new TextEncoder().encode("nip44-v2")
+const VERSION = 2
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/**
+ * Calculate padded length for a plaintext of given unpadded length
+ */
+const calcPaddedLen = (unpaddedLen: number): number => {
+  if (unpaddedLen <= 32) return 32
+
+  const nextPower = 1 << (Math.floor(Math.log2(unpaddedLen - 1)) + 1)
+  const chunk = nextPower <= 256 ? 32 : nextPower / 8
+
+  return chunk * (Math.floor((unpaddedLen - 1) / chunk) + 1)
+}
+
+/**
+ * Pad plaintext according to NIP-44 spec
+ */
+const pad = (plaintext: string): Uint8Array => {
+  const unpadded = new TextEncoder().encode(plaintext)
+  const unpaddedLen = unpadded.length
+
+  if (unpaddedLen < MIN_PLAINTEXT_SIZE || unpaddedLen > MAX_PLAINTEXT_SIZE) {
+    throw new Error(
+      `Invalid plaintext length: ${unpaddedLen}. Must be between ${MIN_PLAINTEXT_SIZE} and ${MAX_PLAINTEXT_SIZE}`
+    )
+  }
+
+  const paddedLen = calcPaddedLen(unpaddedLen)
+  const padded = new Uint8Array(2 + paddedLen)
+
+  // Write length as big-endian u16
+  padded[0] = (unpaddedLen >> 8) & 0xff
+  padded[1] = unpaddedLen & 0xff
+
+  // Copy plaintext
+  padded.set(unpadded, 2)
+
+  // Rest is already zeros
+  return padded
+}
+
+/**
+ * Unpad plaintext according to NIP-44 spec
+ */
+const unpad = (padded: Uint8Array): string => {
+  if (padded.length < 2) {
+    throw new Error("Invalid padded data: too short")
+  }
+
+  // Read length as big-endian u16
+  const unpaddedLen = (padded[0]! << 8) | padded[1]!
+
+  if (unpaddedLen === 0) {
+    throw new Error("Invalid padding: plaintext length is 0")
+  }
+
+  if (padded.length < 2 + unpaddedLen) {
+    throw new Error("Invalid padding: data too short for declared length")
+  }
+
+  const expectedPaddedLen = calcPaddedLen(unpaddedLen)
+  if (padded.length !== 2 + expectedPaddedLen) {
+    throw new Error(
+      `Invalid padding: expected ${2 + expectedPaddedLen} bytes, got ${padded.length}`
+    )
+  }
+
+  const unpadded = padded.slice(2, 2 + unpaddedLen)
+  return new TextDecoder().decode(unpadded)
+}
+
+/**
+ * Derive message keys from conversation key and nonce
+ */
+const getMessageKeys = (
+  conversationKey: Uint8Array,
+  nonce: Uint8Array
+): { chachaKey: Uint8Array; chachaNonce: Uint8Array; hmacKey: Uint8Array } => {
+  if (conversationKey.length !== 32) {
+    throw new Error("Invalid conversation key length")
+  }
+  if (nonce.length !== 32) {
+    throw new Error("Invalid nonce length")
+  }
+
+  // HKDF-expand with conversation_key as PRK, nonce as info, L=76
+  const keys = expand(sha256, conversationKey, nonce, 76)
+
+  return {
+    chachaKey: keys.slice(0, 32),
+    chachaNonce: keys.slice(32, 44),
+    hmacKey: keys.slice(44, 76),
+  }
+}
+
+/**
+ * Calculate HMAC with AAD (nonce prepended to message)
+ */
+const hmacAad = (key: Uint8Array, message: Uint8Array, aad: Uint8Array): Uint8Array => {
+  if (aad.length !== 32) {
+    throw new Error("AAD must be 32 bytes")
+  }
+
+  const combined = new Uint8Array(aad.length + message.length)
+  combined.set(aad)
+  combined.set(message, aad.length)
+
+  return hmac(sha256, key, combined)
+}
+
+/**
+ * Constant-time comparison of two byte arrays
+ */
+const constantTimeEqual = (a: Uint8Array, b: Uint8Array): boolean => {
+  if (a.length !== b.length) return false
+
+  let result = 0
+  for (let i = 0; i < a.length; i++) {
+    result |= a[i]! ^ b[i]!
+  }
+  return result === 0
+}
+
+/**
+ * Decode base64 payload into components
+ */
+const decodePayload = (
+  payload: string
+): { nonce: Uint8Array; ciphertext: Uint8Array; mac: Uint8Array } => {
+  if (payload.length === 0 || payload[0] === "#") {
+    throw new Error("Unknown version or unsupported encoding")
+  }
+
+  if (payload.length < 132 || payload.length > 87472) {
+    throw new Error(`Invalid payload size: ${payload.length}`)
+  }
+
+  // Decode base64
+  const data = Uint8Array.from(atob(payload), (c) => c.charCodeAt(0))
+
+  if (data.length < 99 || data.length > 65603) {
+    throw new Error(`Invalid decoded data size: ${data.length}`)
+  }
+
+  const version = data[0]
+  if (version !== VERSION) {
+    throw new Error(`Unknown version: ${version}`)
+  }
+
+  const nonce = data.slice(1, 33)
+  const ciphertext = data.slice(33, data.length - 32)
+  const mac = data.slice(data.length - 32)
+
+  return { nonce, ciphertext, mac }
+}
+
+// =============================================================================
+// Service Interface
+// =============================================================================
+
+export interface Nip44Service {
+  readonly _tag: "Nip44Service"
+
+  /**
+   * Calculate conversation key from private key A and public key B.
+   * The result is symmetric: conv(a, B) == conv(b, A)
+   */
+  getConversationKey(
+    privateKey: PrivateKey,
+    publicKey: PublicKey
+  ): Effect.Effect<ConversationKey, CryptoError>
+
+  /**
+   * Encrypt plaintext using a conversation key.
+   * Generates a random nonce internally.
+   */
+  encrypt(
+    plaintext: string,
+    conversationKey: ConversationKey
+  ): Effect.Effect<EncryptedPayload, CryptoError>
+
+  /**
+   * Encrypt plaintext with a specific nonce (for testing).
+   * In production, use encrypt() which generates a secure random nonce.
+   */
+  encryptWithNonce(
+    plaintext: string,
+    conversationKey: ConversationKey,
+    nonce: Uint8Array
+  ): Effect.Effect<EncryptedPayload, CryptoError>
+
+  /**
+   * Decrypt a NIP-44 encrypted payload using a conversation key.
+   */
+  decrypt(
+    payload: EncryptedPayload,
+    conversationKey: ConversationKey
+  ): Effect.Effect<string, CryptoError>
+}
+
+// =============================================================================
+// Service Tag
+// =============================================================================
+
+export const Nip44Service = Context.GenericTag<Nip44Service>("Nip44Service")
+
+// =============================================================================
+// Service Implementation
+// =============================================================================
+
+const make: Nip44Service = {
+  _tag: "Nip44Service",
+
+  getConversationKey: (privateKey, publicKey) =>
+    Effect.try({
+      try: () => {
+        const privKeyBytes = hexToBytes(privateKey)
+        // Public key needs to be in compressed format (33 bytes with prefix)
+        // But schnorr public keys are x-only (32 bytes)
+        // We need to reconstruct the full point
+        const pubKeyBytes = hexToBytes(publicKey)
+
+        // For schnorr pubkeys (32 bytes), we need to add the 02 prefix
+        // to make it a valid compressed pubkey for ECDH
+        let fullPubKey: Uint8Array
+        if (pubKeyBytes.length === 32) {
+          fullPubKey = new Uint8Array(33)
+          fullPubKey[0] = 0x02 // Even y coordinate (standard for schnorr)
+          fullPubKey.set(pubKeyBytes, 1)
+        } else {
+          fullPubKey = pubKeyBytes
+        }
+
+        // Perform ECDH: multiply pubkey point by private key scalar
+        const sharedPoint = secp256k1.getSharedSecret(privKeyBytes, fullPubKey)
+
+        // Extract x coordinate (first 32 bytes after the prefix byte)
+        // getSharedSecret returns uncompressed point (65 bytes: 04 + x + y)
+        const sharedX = sharedPoint.slice(1, 33)
+
+        // HKDF-extract with shared_x as IKM and salt
+        const conversationKey = extract(sha256, sharedX, SALT)
+
+        return bytesToHex(conversationKey) as ConversationKey
+      },
+      catch: (error) =>
+        new CryptoError({
+          message: `Failed to derive conversation key: ${error}`,
+          operation: "getConversationKey",
+        }),
+    }),
+
+  encrypt: (plaintext, conversationKey) =>
+    Effect.try({
+      try: () => {
+        const nonce = randomBytes(32)
+        return encryptInternal(plaintext, conversationKey, nonce)
+      },
+      catch: (error) =>
+        new CryptoError({
+          message: `Failed to encrypt: ${error}`,
+          operation: "encrypt",
+        }),
+    }),
+
+  encryptWithNonce: (plaintext, conversationKey, nonce) =>
+    Effect.try({
+      try: () => encryptInternal(plaintext, conversationKey, nonce),
+      catch: (error) =>
+        new CryptoError({
+          message: `Failed to encrypt: ${error}`,
+          operation: "encryptWithNonce",
+        }),
+    }),
+
+  decrypt: (payload, conversationKey) =>
+    Effect.try({
+      try: () => {
+        const { nonce, ciphertext, mac } = decodePayload(payload)
+        const convKeyBytes = hexToBytes(conversationKey)
+
+        const { chachaKey, chachaNonce, hmacKey } = getMessageKeys(convKeyBytes, nonce)
+
+        // Verify MAC
+        const calculatedMac = hmacAad(hmacKey, ciphertext, nonce)
+        if (!constantTimeEqual(calculatedMac, mac)) {
+          throw new Error("Invalid MAC")
+        }
+
+        // Decrypt
+        const paddedPlaintext = chacha20(chachaKey, chachaNonce, ciphertext)
+
+        // Unpad
+        return unpad(paddedPlaintext)
+      },
+      catch: (error) =>
+        new CryptoError({
+          message: `Failed to decrypt: ${error}`,
+          operation: "decrypt",
+        }),
+    }),
+}
+
+/**
+ * Internal encryption function used by both encrypt and encryptWithNonce
+ */
+const encryptInternal = (
+  plaintext: string,
+  conversationKey: ConversationKey,
+  nonce: Uint8Array
+): EncryptedPayload => {
+  const convKeyBytes = hexToBytes(conversationKey)
+
+  const { chachaKey, chachaNonce, hmacKey } = getMessageKeys(convKeyBytes, nonce)
+
+  // Pad plaintext
+  const padded = pad(plaintext)
+
+  // Encrypt with ChaCha20
+  const ciphertext = chacha20(chachaKey, chachaNonce, padded)
+
+  // Calculate MAC with AAD
+  const mac = hmacAad(hmacKey, ciphertext, nonce)
+
+  // Encode: version (1) + nonce (32) + ciphertext + mac (32)
+  const result = new Uint8Array(1 + 32 + ciphertext.length + 32)
+  result[0] = VERSION
+  result.set(nonce, 1)
+  result.set(ciphertext, 33)
+  result.set(mac, 33 + ciphertext.length)
+
+  // Base64 encode
+  return btoa(String.fromCharCode(...result)) as EncryptedPayload
+}
+
+// =============================================================================
+// Service Layer
+// =============================================================================
+
+export const Nip44ServiceLive = Layer.succeed(Nip44Service, make)


### PR DESCRIPTION
## Summary
- Add Nip44Service for NIP-44 encrypted payloads (version 2)
- secp256k1 ECDH for shared secret derivation
- HKDF-extract for conversation key generation
- HKDF-expand for per-message key derivation
- ChaCha20 for symmetric encryption
- HMAC-SHA256 for message authentication (with AAD)
- Custom padding scheme for message length obfuscation
- Full bidirectional communication support

Closes #19

## Test plan
- [x] `bun run verify` passes (188 tests, 0 failures)
- [x] Tests match official NIP-44 test vectors
- [x] Tests cover conversation key derivation symmetry
- [x] Tests cover encrypt/decrypt round-trip
- [x] Tests cover various message sizes (1 byte to 1000+ bytes)
- [x] Tests cover unicode messages
- [x] Tests verify random nonce produces different ciphertext
- [x] Tests cover error cases (invalid MAC, wrong key, empty payload)
- [x] Tests cover bidirectional Alice-Bob communication

🤖 Generated with [Claude Code](https://claude.com/claude-code)