### PR TITLE
Relay: NIP Module system for pluggable NIP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Building both sides of the protocol in tandem - using each to test the other.
 - [x] PolicyPipeline (composable event validation)
 - [x] NIP-16/33 Replaceable Events
 - [x] NIP-11 Relay Information Document
-- [ ] NIP module system
+- [x] NIP module system (pluggable NIP support)
 - [ ] ConnectionManager
 - [ ] NIP-42 Authentication
 

--- a/docs/BUILDOUT.md
+++ b/docs/BUILDOUT.md
@@ -29,22 +29,25 @@ src/
 
 ### Completed
 - **Core**: Schema.ts (NIP-01 types), Errors.ts, Nip19.ts (bech32 encoding)
-- **Services**: CryptoService, EventService
-- **Relay**: EventStore, SubscriptionManager, MessageHandler, RelayServer, PolicyPipeline, NIP-16/33 Replaceable Events, NIP-11 Relay Info
+- **Services**: CryptoService, EventService, Nip44Service (NIP-44 versioned encryption)
+- **Relay**: EventStore, SubscriptionManager, MessageHandler, RelayServer, PolicyPipeline, NIP-16/33 Replaceable Events, NIP-11 Relay Info, NIP Module System
+- **Relay Backends**: Bun (SQLite), Cloudflare Durable Objects (DO SQLite)
 - **Client**: RelayService (WebSocket connection management), FollowListService (NIP-02), RelayListService (NIP-65), HandlerService (NIP-89), DVMService (NIP-90)
-- **Services**: Nip44Service (NIP-44 versioned encryption)
+
+### In Progress
+- None
 
 ### Open Issues
 
 **Relay (#5-13)**
 | Issue | Description |
 |-------|-------------|
-| #5 | NIP Module system |
+| ~~#5~~ | ~~NIP Module system~~ ✅ |
 | #6 | ConnectionManager |
 | #7 | NIP-09 Deletion |
 | ~~#8~~ | ~~NIP-11 Relay Info~~ ✅ |
 | ~~#9~~ | ~~NIP-16/33 Replaceable Events~~ ✅ |
-| #10 | NIP-22 Timestamp Limits |
+| #10 | Timestamp Limits (NIP-11 limitation) |
 | #11 | NIP-40 Expiration |
 | #12 | NIP-42 Authentication |
 | #13 | Rate Limiting |
@@ -83,7 +86,7 @@ src/
 | 2.1 | ✅ #9: Replaceable | ✅ #20: NIP-02 Follow Lists | Client needs relay for kind 3 |
 | 2.2 | ✅ #9: Replaceable | ✅ #21: NIP-65 Relay Lists | Client needs relay for kind 10002 |
 | 2.3 | ✅ #8: NIP-11 Info | - | Client reads relay capabilities |
-| 2.4 | #10: NIP-22 | - | Timestamp bounds (policy exists) |
+| 2.4 | #10: Timestamp Limits | - | created_at bounds (NIP-11 limitation) |
 | 2.5 | - | #18: NIP-05 | Independent (HTTP only) |
 
 ### Phase 3: DVM & Discovery
@@ -111,7 +114,7 @@ src/
 | 5.1 | #7: NIP-09 Deletion | - | Soft delete |
 | 5.2 | #11: NIP-40 Expiration | - | Event TTL |
 | 5.3 | #13: Rate Limiting | - | Security |
-| 5.4 | #5: NIP Module System | - | Pluggable NIPs |
+| 5.4 | ✅ #5: NIP Module System | - | Pluggable NIPs |
 | 5.5 | - | #23: RelayPool | Multi-relay |
 | 5.6 | - | #24: NIP-46 | Remote signing |
 

--- a/src/core/Schema.ts
+++ b/src/core/Schema.ts
@@ -242,6 +242,16 @@ export const isAnyReplaceableKind = (kind: EventKind | number): boolean =>
   isReplaceableKind(kind) || isParameterizedReplaceableKind(kind)
 
 /**
+ * Check if an event kind is ephemeral (NIP-16)
+ * Ephemeral kinds: 20000-29999
+ * These events are not stored, only broadcast to subscribers
+ */
+export const isEphemeralKind = (kind: EventKind | number): boolean => {
+  const k = kind as number
+  return k >= 20000 && k <= 29999
+}
+
+/**
  * Get the d-tag value from an event's tags
  * Used for parameterized replaceable events
  */

--- a/src/relay/core/index.ts
+++ b/src/relay/core/index.ts
@@ -9,6 +9,7 @@
 export {
   MessageHandler,
   MessageHandlerLive,
+  MessageHandlerWithRegistry,
   type HandleResult,
   type BroadcastMessage,
 } from "./MessageHandler.js"
@@ -35,3 +36,6 @@ export {
 
 // Policy module
 export * from "./policy/index.js"
+
+// NIP module system
+export * from "./nip/index.js"

--- a/src/relay/core/nip/NipModule.ts
+++ b/src/relay/core/nip/NipModule.ts
@@ -1,0 +1,178 @@
+/**
+ * NipModule
+ *
+ * Interface for pluggable NIP support in the relay.
+ * Each module can contribute policies, kind handlers, and relay info.
+ */
+import type { Effect } from "effect"
+import type { NostrEvent } from "../../../core/Schema.js"
+import type { Policy } from "../policy/Policy.js"
+import type { RelayInfo, RelayLimitation } from "../RelayInfo.js"
+import type { CryptoError, InvalidPublicKey } from "../../../core/Errors.js"
+import type { EventService } from "../../../services/EventService.js"
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Hook called before an event is stored
+ * Can modify the event or reject it
+ */
+export type PreStoreHook = (
+  event: NostrEvent
+) => Effect.Effect<
+  | { readonly action: "store"; readonly event: NostrEvent }
+  | { readonly action: "replace"; readonly event: NostrEvent; readonly deleteFilter?: EventDeleteFilter }
+  | { readonly action: "reject"; readonly reason: string },
+  never
+>
+
+/**
+ * Filter for events to delete when replacing
+ */
+export interface EventDeleteFilter {
+  readonly kinds?: readonly number[]
+  readonly authors?: readonly string[]
+  readonly dTag?: string // For parameterized replaceable events
+}
+
+/**
+ * Hook called after an event is stored
+ * For side effects like notifications, indexing, etc.
+ */
+export type PostStoreHook = (event: NostrEvent) => Effect.Effect<void, never>
+
+/**
+ * NIP Module interface
+ *
+ * Modules can provide:
+ * - policies: Validation rules for events
+ * - preStoreHook: Pre-processing before storage (e.g., replaceable event handling)
+ * - postStoreHook: Post-processing after storage
+ * - relayInfo: Contributions to NIP-11 relay info
+ */
+export interface NipModule {
+  /**
+   * Module identifier (e.g., "nip-01", "nip-09", "nip-16")
+   */
+  readonly id: string
+
+  /**
+   * NIP numbers this module implements
+   */
+  readonly nips: readonly number[]
+
+  /**
+   * Human-readable description
+   */
+  readonly description: string
+
+  /**
+   * Event kinds this module handles (for routing)
+   * Empty array means module applies to all kinds
+   */
+  readonly kinds: readonly number[]
+
+  /**
+   * Policies contributed by this module
+   * Combined with other modules using `all` combinator
+   */
+  readonly policies: readonly Policy<CryptoError | InvalidPublicKey, EventService>[]
+
+  /**
+   * Pre-store hook for event processing
+   * Called before storing an event
+   */
+  readonly preStoreHook?: PreStoreHook
+
+  /**
+   * Post-store hook for side effects
+   * Called after successfully storing an event
+   */
+  readonly postStoreHook?: PostStoreHook
+
+  /**
+   * Contributions to NIP-11 relay info
+   */
+  readonly relayInfo?: Partial<RelayInfo>
+
+  /**
+   * Contributions to relay limitations
+   */
+  readonly limitations?: Partial<RelayLimitation>
+}
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/**
+ * Create a NIP module with defaults
+ */
+export const createModule = (
+  config: Omit<NipModule, "policies"> & {
+    policies?: NipModule["policies"]
+  }
+): NipModule => ({
+  policies: [],
+  ...config,
+})
+
+/**
+ * Check if a module handles a specific kind
+ */
+export const handlesKind = (module: NipModule, kind: number): boolean =>
+  module.kinds.length === 0 || module.kinds.includes(kind)
+
+/**
+ * Get all NIPs from a list of modules
+ */
+export const getAllNips = (modules: readonly NipModule[]): readonly number[] => {
+  const nips = new Set<number>()
+  for (const module of modules) {
+    for (const nip of module.nips) {
+      nips.add(nip)
+    }
+  }
+  return [...nips].sort((a, b) => a - b)
+}
+
+/**
+ * Merge relay info from multiple modules
+ */
+export const mergeRelayInfo = (
+  modules: readonly NipModule[],
+  base: Partial<RelayInfo> = {}
+): Partial<RelayInfo> => {
+  // Collect all supported NIPs
+  const supportedNips = getAllNips(modules)
+
+  // Merge limitations
+  let limitations: Partial<RelayLimitation> = {}
+  for (const module of modules) {
+    if (module.limitations) {
+      limitations = { ...limitations, ...module.limitations }
+    }
+    if (module.relayInfo?.limitation) {
+      limitations = { ...limitations, ...module.relayInfo.limitation }
+    }
+  }
+
+  // Merge other relay info (last wins for conflicts)
+  let merged: Partial<RelayInfo> = { ...base }
+  for (const module of modules) {
+    if (module.relayInfo) {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { limitation, supported_nips, ...rest } = module.relayInfo
+      merged = { ...merged, ...rest }
+    }
+  }
+
+  // Build final result
+  return {
+    ...merged,
+    supported_nips: supportedNips,
+    ...(Object.keys(limitations).length > 0 && { limitation: limitations as RelayLimitation }),
+  }
+}

--- a/src/relay/core/nip/NipRegistry.test.ts
+++ b/src/relay/core/nip/NipRegistry.test.ts
@@ -1,0 +1,337 @@
+/**
+ * NIP Module System Tests
+ */
+import { describe, it, expect } from "bun:test"
+import { Effect } from "effect"
+import {
+  type NipModule,
+  createModule,
+  handlesKind,
+  getAllNips,
+  mergeRelayInfo,
+} from "./NipModule.js"
+import { NipRegistry, NipRegistryLive } from "./NipRegistry.js"
+import { Nip01Module, createNip01Module } from "./modules/Nip01Module.js"
+import { Nip11Module, createNip11Module } from "./modules/Nip11Module.js"
+import { Nip16Module } from "./modules/Nip16Module.js"
+import { DefaultModules } from "./modules/index.js"
+import type { NostrEvent } from "../../../core/Schema.js"
+
+// =============================================================================
+// Test Fixtures
+// =============================================================================
+
+const createTestEvent = (overrides: Partial<{
+  id: string
+  pubkey: string
+  created_at: number
+  kind: number
+  tags: string[][]
+  content: string
+  sig: string
+}> = {}): NostrEvent =>
+  ({
+    id: "test-id",
+    pubkey: "test-pubkey",
+    created_at: Math.floor(Date.now() / 1000),
+    kind: 1,
+    tags: [],
+    content: "test content",
+    sig: "test-sig",
+    ...overrides,
+  }) as unknown as NostrEvent
+
+// =============================================================================
+// NipModule Tests
+// =============================================================================
+
+describe("NipModule", () => {
+  describe("createModule", () => {
+    it("should create a module with defaults", () => {
+      const module = createModule({
+        id: "test",
+        nips: [99],
+        description: "Test module",
+        kinds: [1, 2],
+      })
+
+      expect(module.id).toBe("test")
+      expect(module.nips).toEqual([99])
+      expect(module.description).toBe("Test module")
+      expect(module.kinds).toEqual([1, 2])
+      expect(module.policies).toEqual([])
+    })
+  })
+
+  describe("handlesKind", () => {
+    it("should return true if kinds is empty (handles all)", () => {
+      const module = createModule({
+        id: "test",
+        nips: [1],
+        description: "Test",
+        kinds: [],
+      })
+
+      expect(handlesKind(module, 1)).toBe(true)
+      expect(handlesKind(module, 9999)).toBe(true)
+    })
+
+    it("should return true only for specified kinds", () => {
+      const module = createModule({
+        id: "test",
+        nips: [1],
+        description: "Test",
+        kinds: [1, 3, 10002],
+      })
+
+      expect(handlesKind(module, 1)).toBe(true)
+      expect(handlesKind(module, 3)).toBe(true)
+      expect(handlesKind(module, 10002)).toBe(true)
+      expect(handlesKind(module, 2)).toBe(false)
+      expect(handlesKind(module, 9999)).toBe(false)
+    })
+  })
+
+  describe("getAllNips", () => {
+    it("should collect all unique NIPs from modules", () => {
+      const modules: NipModule[] = [
+        createModule({ id: "a", nips: [1, 11], description: "", kinds: [] }),
+        createModule({ id: "b", nips: [11, 16], description: "", kinds: [] }),
+        createModule({ id: "c", nips: [33], description: "", kinds: [] }),
+      ]
+
+      const nips = getAllNips(modules)
+      expect(nips).toEqual([1, 11, 16, 33])
+    })
+
+    it("should return empty array for no modules", () => {
+      expect(getAllNips([])).toEqual([])
+    })
+  })
+
+  describe("mergeRelayInfo", () => {
+    it("should merge relay info from multiple modules", () => {
+      const modules: NipModule[] = [
+        createModule({
+          id: "a",
+          nips: [1],
+          description: "",
+          kinds: [],
+          relayInfo: { name: "Test Relay" },
+        }),
+        createModule({
+          id: "b",
+          nips: [11],
+          description: "",
+          kinds: [],
+          relayInfo: { description: "A test relay" },
+        }),
+      ]
+
+      const info = mergeRelayInfo(modules)
+      expect(info.name).toBe("Test Relay")
+      expect(info.description).toBe("A test relay")
+      expect(info.supported_nips).toEqual([1, 11])
+    })
+
+    it("should merge limitations from modules", () => {
+      const modules: NipModule[] = [
+        createModule({
+          id: "a",
+          nips: [1],
+          description: "",
+          kinds: [],
+          limitations: { max_content_length: 64000 },
+        }),
+        createModule({
+          id: "b",
+          nips: [11],
+          description: "",
+          kinds: [],
+          limitations: { max_event_tags: 2000 },
+        }),
+      ]
+
+      const info = mergeRelayInfo(modules)
+      expect(info.limitation?.max_content_length).toBe(64000)
+      expect(info.limitation?.max_event_tags).toBe(2000)
+    })
+
+    it("should use base info", () => {
+      const modules: NipModule[] = [
+        createModule({ id: "a", nips: [1], description: "", kinds: [] }),
+      ]
+
+      const info = mergeRelayInfo(modules, { version: "1.0.0" })
+      expect(info.version).toBe("1.0.0")
+    })
+  })
+})
+
+// =============================================================================
+// Built-in Module Tests
+// =============================================================================
+
+describe("Built-in Modules", () => {
+  describe("Nip01Module", () => {
+    it("should have correct NIP number", () => {
+      expect(Nip01Module.nips).toEqual([1])
+    })
+
+    it("should have policies for signature, content, and tags", () => {
+      expect(Nip01Module.policies.length).toBe(3)
+    })
+
+    it("should be configurable", () => {
+      const custom = createNip01Module({
+        maxContentLength: 1000,
+        maxTags: 100,
+      })
+
+      expect(custom.limitations?.max_content_length).toBe(1000)
+      expect(custom.limitations?.max_event_tags).toBe(100)
+    })
+  })
+
+  describe("Nip11Module", () => {
+    it("should have correct NIP number", () => {
+      expect(Nip11Module.nips).toEqual([11])
+    })
+
+    it("should be configurable", () => {
+      const custom = createNip11Module({
+        name: "My Relay",
+        description: "My description",
+        pubkey: "abc123",
+      })
+
+      expect(custom.relayInfo?.name).toBe("My Relay")
+      expect(custom.relayInfo?.description).toBe("My description")
+      expect(custom.relayInfo?.pubkey).toBe("abc123")
+    })
+  })
+
+  describe("Nip16Module", () => {
+    it("should have correct NIP numbers", () => {
+      expect(Nip16Module.nips).toEqual([16, 33])
+    })
+
+    it("should have a pre-store hook", () => {
+      expect(Nip16Module.preStoreHook).toBeDefined()
+    })
+
+    it("should return store action for regular events", async () => {
+      const event = createTestEvent({ kind: 1 })
+      const result = await Effect.runPromise(Nip16Module.preStoreHook!(event))
+
+      expect(result.action).toBe("store")
+      if (result.action === "store") {
+        expect(result.event).toBe(event)
+      }
+    })
+
+    it("should return replace action for replaceable events", async () => {
+      const event = createTestEvent({ kind: 0 }) // kind 0 is replaceable
+      const result = await Effect.runPromise(Nip16Module.preStoreHook!(event))
+
+      expect(result.action).toBe("replace")
+      if (result.action === "replace") {
+        expect(result.deleteFilter?.kinds).toEqual([0])
+        expect(result.deleteFilter?.authors).toEqual(["test-pubkey"])
+      }
+    })
+
+    it("should return replace action for parameterized replaceable events", async () => {
+      const event = createTestEvent({
+        kind: 30000,
+        tags: [["d", "my-identifier"]],
+      })
+      const result = await Effect.runPromise(Nip16Module.preStoreHook!(event))
+
+      expect(result.action).toBe("replace")
+      if (result.action === "replace") {
+        expect(result.deleteFilter?.kinds).toEqual([30000])
+        expect(result.deleteFilter?.dTag).toBe("my-identifier")
+      }
+    })
+  })
+
+  describe("DefaultModules", () => {
+    it("should include NIP-01, NIP-11, and NIP-16", () => {
+      const nips = getAllNips(DefaultModules)
+      expect(nips).toContain(1)
+      expect(nips).toContain(11)
+      expect(nips).toContain(16)
+      expect(nips).toContain(33)
+    })
+  })
+})
+
+// =============================================================================
+// NipRegistry Tests
+// =============================================================================
+
+describe("NipRegistry", () => {
+  it("should create registry with modules", () => {
+    const registry = Effect.runSync(
+      Effect.gen(function* () {
+        return yield* NipRegistry
+      }).pipe(Effect.provide(NipRegistryLive(DefaultModules)))
+    )
+
+    expect(registry.modules.length).toBe(3)
+    expect(registry.supportedNips).toEqual([1, 11, 16, 33])
+  })
+
+  it("should check if module exists", () => {
+    const registry = Effect.runSync(
+      Effect.gen(function* () {
+        return yield* NipRegistry
+      }).pipe(Effect.provide(NipRegistryLive(DefaultModules)))
+    )
+
+    expect(registry.hasModule("nip-01")).toBe(true)
+    expect(registry.hasModule("nip-99")).toBe(false)
+  })
+
+  it("should get module by ID", () => {
+    const registry = Effect.runSync(
+      Effect.gen(function* () {
+        return yield* NipRegistry
+      }).pipe(Effect.provide(NipRegistryLive(DefaultModules)))
+    )
+
+    const module = registry.getModule("nip-16")
+    expect(module?.nips).toEqual([16, 33])
+  })
+
+  it("should get combined relay info", () => {
+    const registry = Effect.runSync(
+      Effect.gen(function* () {
+        return yield* NipRegistry
+      }).pipe(Effect.provide(NipRegistryLive(DefaultModules)))
+    )
+
+    const info = registry.getRelayInfo()
+    expect(info.supported_nips).toEqual([1, 11, 16, 33])
+    expect(info.name).toBe("nostr-effect relay")
+  })
+
+  it("should run pre-store hooks", async () => {
+    const registry = Effect.runSync(
+      Effect.gen(function* () {
+        return yield* NipRegistry
+      }).pipe(Effect.provide(NipRegistryLive(DefaultModules)))
+    )
+
+    // Regular event
+    const regularEvent = createTestEvent({ kind: 1 })
+    const result1 = await Effect.runPromise(registry.runPreStoreHooks(regularEvent))
+    expect(result1.action).toBe("store")
+
+    // Replaceable event
+    const replaceableEvent = createTestEvent({ kind: 0 })
+    const result2 = await Effect.runPromise(registry.runPreStoreHooks(replaceableEvent))
+    expect(result2.action).toBe("replace")
+  })
+})

--- a/src/relay/core/nip/NipRegistry.ts
+++ b/src/relay/core/nip/NipRegistry.ts
@@ -1,0 +1,169 @@
+/**
+ * NipRegistry
+ *
+ * Service for managing and combining NIP modules.
+ * Provides a unified interface for policies, hooks, and relay info.
+ */
+import { Context, Effect, Layer } from "effect"
+import type { NostrEvent } from "../../../core/Schema.js"
+import type { CryptoError, InvalidPublicKey } from "../../../core/Errors.js"
+import { EventService } from "../../../services/EventService.js"
+import { type Policy, all, Accept } from "../policy/Policy.js"
+import {
+  type NipModule,
+  handlesKind,
+  getAllNips,
+  mergeRelayInfo,
+} from "./NipModule.js"
+import type { RelayInfo } from "../RelayInfo.js"
+
+// =============================================================================
+// Service Interface
+// =============================================================================
+
+export interface NipRegistry {
+  readonly _tag: "NipRegistry"
+
+  /**
+   * Get all registered modules
+   */
+  readonly modules: readonly NipModule[]
+
+  /**
+   * Get all supported NIP numbers
+   */
+  readonly supportedNips: readonly number[]
+
+  /**
+   * Get combined relay info from all modules
+   */
+  getRelayInfo(base?: Partial<RelayInfo>): Partial<RelayInfo>
+
+  /**
+   * Get combined policy from all modules
+   */
+  getPolicy(): Policy<CryptoError | InvalidPublicKey, EventService>
+
+  /**
+   * Run pre-store hooks for an event
+   * Returns the processed event or rejection
+   */
+  runPreStoreHooks(
+    event: NostrEvent
+  ): Effect.Effect<
+    | { readonly action: "store"; readonly event: NostrEvent }
+    | { readonly action: "replace"; readonly event: NostrEvent; readonly deleteFilter?: { kinds?: readonly number[]; authors?: readonly string[]; dTag?: string } }
+    | { readonly action: "reject"; readonly reason: string },
+    never
+  >
+
+  /**
+   * Run post-store hooks for an event
+   */
+  runPostStoreHooks(event: NostrEvent): Effect.Effect<void, never>
+
+  /**
+   * Check if a module is registered by ID
+   */
+  hasModule(id: string): boolean
+
+  /**
+   * Get a module by ID
+   */
+  getModule(id: string): NipModule | undefined
+}
+
+// =============================================================================
+// Service Tag
+// =============================================================================
+
+export const NipRegistry = Context.GenericTag<NipRegistry>("NipRegistry")
+
+// =============================================================================
+// Service Implementation
+// =============================================================================
+
+const make = (modules: readonly NipModule[]): NipRegistry => {
+  const moduleMap = new Map(modules.map((m) => [m.id, m]))
+  const supportedNips = getAllNips(modules)
+
+  // Combine all policies from all modules
+  const combinedPolicy: Policy<CryptoError | InvalidPublicKey, EventService> = (ctx) => {
+    const applicablePolicies = modules
+      .filter((m) => handlesKind(m, ctx.event.kind))
+      .flatMap((m) => m.policies)
+
+    if (applicablePolicies.length === 0) {
+      return Effect.succeed(Accept)
+    }
+
+    return all(...applicablePolicies)(ctx)
+  }
+
+  return {
+    _tag: "NipRegistry",
+    modules,
+    supportedNips,
+
+    getRelayInfo: (base) => mergeRelayInfo(modules, base),
+
+    getPolicy: () => combinedPolicy,
+
+    runPreStoreHooks: (event) =>
+      Effect.gen(function* () {
+        let currentEvent = event
+
+        // Get modules that handle this kind and have pre-store hooks
+        const applicableModules = modules.filter(
+          (m) => m.preStoreHook && handlesKind(m, event.kind)
+        )
+
+        for (const module of applicableModules) {
+          const result = yield* module.preStoreHook!(currentEvent)
+
+          if (result.action === "reject") {
+            return result
+          }
+
+          if (result.action === "replace") {
+            return result
+          }
+
+          // action === "store" - continue with potentially modified event
+          currentEvent = result.event
+        }
+
+        return { action: "store" as const, event: currentEvent }
+      }),
+
+    runPostStoreHooks: (event) =>
+      Effect.gen(function* () {
+        const applicableModules = modules.filter(
+          (m) => m.postStoreHook && handlesKind(m, event.kind)
+        )
+
+        for (const module of applicableModules) {
+          yield* module.postStoreHook!(event)
+        }
+      }),
+
+    hasModule: (id) => moduleMap.has(id),
+
+    getModule: (id) => moduleMap.get(id),
+  }
+}
+
+// =============================================================================
+// Service Layers
+// =============================================================================
+
+/**
+ * Create NipRegistry with specific modules
+ */
+export const NipRegistryLive = (modules: readonly NipModule[]) =>
+  Layer.succeed(NipRegistry, make(modules))
+
+/**
+ * Empty registry (for testing)
+ */
+export const NipRegistryEmpty = Layer.succeed(NipRegistry, make([]))

--- a/src/relay/core/nip/index.ts
+++ b/src/relay/core/nip/index.ts
@@ -1,0 +1,23 @@
+/**
+ * NIP Module System
+ *
+ * Pluggable NIP support for the relay.
+ */
+
+// Core types and interfaces
+export {
+  type NipModule,
+  type PreStoreHook,
+  type PostStoreHook,
+  type EventDeleteFilter,
+  createModule,
+  handlesKind,
+  getAllNips,
+  mergeRelayInfo,
+} from "./NipModule.js"
+
+// Registry service
+export { NipRegistry, NipRegistryLive, NipRegistryEmpty } from "./NipRegistry.js"
+
+// Built-in modules
+export * from "./modules/index.js"

--- a/src/relay/core/nip/modules/Nip01Module.ts
+++ b/src/relay/core/nip/modules/Nip01Module.ts
@@ -1,0 +1,58 @@
+/**
+ * NIP-01 Module
+ *
+ * Basic protocol flow - event types, filters, and signatures.
+ * This is the foundation module that every relay needs.
+ */
+import { type NipModule, createModule } from "../NipModule.js"
+import { verifySignature, maxContentLength, maxTags } from "../../policy/BuiltInPolicies.js"
+
+// =============================================================================
+// Configuration
+// =============================================================================
+
+export interface Nip01Config {
+  /** Maximum content length in bytes (default: 64KB) */
+  readonly maxContentLength?: number
+  /** Maximum number of tags per event (default: 2000) */
+  readonly maxTags?: number
+}
+
+const DEFAULT_CONFIG: Required<Nip01Config> = {
+  maxContentLength: 64 * 1024, // 64KB
+  maxTags: 2000,
+}
+
+// =============================================================================
+// Module
+// =============================================================================
+
+/**
+ * Create NIP-01 module with optional configuration
+ */
+export const createNip01Module = (config: Nip01Config = {}): NipModule => {
+  const cfg = { ...DEFAULT_CONFIG, ...config }
+
+  return createModule({
+    id: "nip-01",
+    nips: [1],
+    description: "Basic protocol flow: events, filters, subscriptions",
+    kinds: [], // Applies to all kinds
+
+    policies: [
+      verifySignature,
+      maxContentLength(cfg.maxContentLength),
+      maxTags(cfg.maxTags),
+    ],
+
+    limitations: {
+      max_content_length: cfg.maxContentLength,
+      max_event_tags: cfg.maxTags,
+    },
+  })
+}
+
+/**
+ * Default NIP-01 module instance
+ */
+export const Nip01Module = createNip01Module()

--- a/src/relay/core/nip/modules/Nip11Module.ts
+++ b/src/relay/core/nip/modules/Nip11Module.ts
@@ -1,0 +1,62 @@
+/**
+ * NIP-11 Module
+ *
+ * Relay Information Document - metadata about the relay.
+ */
+import { type NipModule, createModule } from "../NipModule.js"
+import type { RelayInfo } from "../../RelayInfo.js"
+
+// =============================================================================
+// Configuration
+// =============================================================================
+
+export interface Nip11Config {
+  /** Relay name */
+  readonly name?: string
+  /** Relay description */
+  readonly description?: string
+  /** Admin pubkey (32-byte hex) */
+  readonly pubkey?: string
+  /** Contact information (email, URL, etc.) */
+  readonly contact?: string
+  /** Software URL */
+  readonly software?: string
+  /** Software version */
+  readonly version?: string
+}
+
+// =============================================================================
+// Module
+// =============================================================================
+
+/**
+ * Create NIP-11 module with relay info configuration
+ */
+export const createNip11Module = (config: Nip11Config = {}): NipModule => {
+  const relayInfo: Partial<RelayInfo> = {
+    ...(config.name && { name: config.name }),
+    ...(config.description && { description: config.description }),
+    ...(config.pubkey && { pubkey: config.pubkey }),
+    ...(config.contact && { contact: config.contact }),
+    ...(config.software && { software: config.software }),
+    ...(config.version && { version: config.version }),
+  }
+
+  return createModule({
+    id: "nip-11",
+    nips: [11],
+    description: "Relay Information Document",
+    kinds: [], // Doesn't handle any specific kinds
+    relayInfo,
+  })
+}
+
+/**
+ * Default NIP-11 module with minimal info
+ */
+export const Nip11Module = createNip11Module({
+  name: "nostr-effect relay",
+  description: "Effect-based Nostr relay implementation",
+  software: "https://github.com/OpenAgentsInc/nostr-effect",
+  version: "0.1.0",
+})

--- a/src/relay/core/nip/modules/Nip16Module.ts
+++ b/src/relay/core/nip/modules/Nip16Module.ts
@@ -1,0 +1,76 @@
+/**
+ * NIP-16 Module
+ *
+ * Event treatment - replaceable and ephemeral events.
+ * Includes NIP-33 for parameterized replaceable events.
+ */
+import { Effect } from "effect"
+import { type NipModule, createModule } from "../NipModule.js"
+import {
+  isReplaceableKind,
+  isEphemeralKind,
+  isParameterizedReplaceableKind,
+  getDTagValue,
+} from "../../../../core/Schema.js"
+
+// =============================================================================
+// Module
+// =============================================================================
+
+/**
+ * NIP-16/33 Module for replaceable and parameterized replaceable events
+ *
+ * Replaceable events (kinds 0, 3, 10000-19999):
+ * - Only the latest event per pubkey+kind is kept
+ *
+ * Parameterized replaceable events (kinds 30000-39999):
+ * - Only the latest event per pubkey+kind+d-tag is kept
+ *
+ * Ephemeral events (kinds 20000-29999):
+ * - Not stored, only broadcast to subscribers
+ */
+export const Nip16Module: NipModule = createModule({
+  id: "nip-16",
+  nips: [16, 33],
+  description: "Event treatment: replaceable, parameterized replaceable, and ephemeral events",
+  kinds: [], // We check kind ranges in the hook
+
+  preStoreHook: (event) =>
+    Effect.sync(() => {
+      // Ephemeral events - don't store, just broadcast
+      if (isEphemeralKind(event.kind)) {
+        // For now, we still store ephemeral events but they could be filtered
+        // In a full implementation, we'd return a special "broadcast-only" action
+        return { action: "store", event } as const
+      }
+
+      // Replaceable events - delete old, store new
+      if (isReplaceableKind(event.kind)) {
+        return {
+          action: "replace",
+          event,
+          deleteFilter: {
+            kinds: [event.kind] as readonly number[],
+            authors: [event.pubkey] as readonly string[],
+          },
+        } as const
+      }
+
+      // Parameterized replaceable events - delete old with same d-tag
+      if (isParameterizedReplaceableKind(event.kind)) {
+        const dTag = getDTagValue(event) ?? "" // Default to empty string for d-tag
+        return {
+          action: "replace",
+          event,
+          deleteFilter: {
+            kinds: [event.kind] as readonly number[],
+            authors: [event.pubkey] as readonly string[],
+            dTag,
+          },
+        } as const
+      }
+
+      // Regular events - just store
+      return { action: "store", event } as const
+    }),
+})

--- a/src/relay/core/nip/modules/index.ts
+++ b/src/relay/core/nip/modules/index.ts
@@ -1,0 +1,29 @@
+/**
+ * NIP Modules Index
+ *
+ * Re-exports all NIP modules and provides default module set.
+ */
+
+// Module exports
+export { Nip01Module, createNip01Module, type Nip01Config } from "./Nip01Module.js"
+export { Nip11Module, createNip11Module, type Nip11Config } from "./Nip11Module.js"
+export { Nip16Module } from "./Nip16Module.js"
+
+// =============================================================================
+// Default Module Set
+// =============================================================================
+
+import { Nip01Module } from "./Nip01Module.js"
+import { Nip11Module } from "./Nip11Module.js"
+import { Nip16Module } from "./Nip16Module.js"
+import type { NipModule } from "../NipModule.js"
+
+/**
+ * Default set of NIP modules for a basic relay
+ * Includes: NIP-01 (basic), NIP-11 (info), NIP-16/33 (replaceable events)
+ */
+export const DefaultModules: readonly NipModule[] = [
+  Nip01Module,
+  Nip11Module,
+  Nip16Module,
+]

--- a/src/relay/core/policy/index.ts
+++ b/src/relay/core/policy/index.ts
@@ -41,5 +41,6 @@ export {
   PolicyPipeline,
   PolicyPipelineLive,
   PolicyPipelineCustom,
+  PolicyPipelineFromRegistry,
   PolicyPipelinePermissive,
 } from "./PolicyPipeline.js"


### PR DESCRIPTION
## Summary
Implements a pluggable NIP module system for the relay:

- **NipModule interface**: Defines how NIPs contribute policies, hooks, and relay info
- **NipRegistry service**: Manages and combines multiple NIP modules
- **Built-in modules**: Nip01Module (basic protocol), Nip11Module (relay info), Nip16Module (replaceable events)
- **DefaultModules preset**: Quick setup with standard NIPs

## Files Added
- `src/relay/core/nip/NipModule.ts` - Interface and helpers
- `src/relay/core/nip/NipRegistry.ts` - Registry service
- `src/relay/core/nip/modules/Nip01Module.ts` - NIP-01 basic protocol
- `src/relay/core/nip/modules/Nip11Module.ts` - NIP-11 relay info
- `src/relay/core/nip/modules/Nip16Module.ts` - NIP-16/33 replaceable events
- `src/relay/core/nip/NipRegistry.test.ts` - 24 tests

## Usage Example
```typescript
import { NipRegistry, NipRegistryLive, DefaultModules } from "./src/relay/core/nip"

// Use default modules (NIP-01, NIP-11, NIP-16/33)
const program = Effect.gen(function* () {
  const registry = yield* NipRegistry
  const info = registry.getRelayInfo()
  // info.supported_nips = [1, 11, 16, 33]
}).pipe(Effect.provide(NipRegistryLive(DefaultModules)))
```

## Test plan
- [x] `bun run verify` passes (278 tests, +24 new)
- [x] Module creation and kind handling
- [x] NIP collection and relay info merging
- [x] Pre-store hooks for replaceable events
- [x] Registry module lookup

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)