### PR TITLE
Relay: Add timestamp limits to NIP module system

### DIFF
--- a/docs/BUILDOUT.md
+++ b/docs/BUILDOUT.md
@@ -35,7 +35,7 @@ src/
 - **Client**: RelayService (WebSocket connection management), FollowListService (NIP-02), RelayListService (NIP-65), HandlerService (NIP-89), DVMService (NIP-90)
 
 ### In Progress
-- None
+- **Relay**: #10 Timestamp Limits (NIP-11 limitation)
 
 ### Open Issues
 

--- a/src/relay/core/nip/NipRegistry.test.ts
+++ b/src/relay/core/nip/NipRegistry.test.ts
@@ -191,6 +191,28 @@ describe("Built-in Modules", () => {
       expect(custom.limitations?.max_content_length).toBe(1000)
       expect(custom.limitations?.max_event_tags).toBe(100)
     })
+
+    it("should support timestamp limits", () => {
+      const custom = createNip01Module({
+        maxFutureSeconds: 60,
+        maxPastSeconds: 3600,
+      })
+
+      // Should add timestamp policies (signature + content + tags + 2 timestamp = 5)
+      expect(custom.policies.length).toBe(5)
+      // Should report limits in NIP-11
+      expect(custom.limitations?.created_at_upper_limit).toBe(60)
+      expect(custom.limitations?.created_at_lower_limit).toBe(3600)
+    })
+
+    it("should not include timestamp limits when not configured", () => {
+      const custom = createNip01Module({})
+
+      // Only signature, content, tags
+      expect(custom.policies.length).toBe(3)
+      expect(custom.limitations?.created_at_upper_limit).toBeUndefined()
+      expect(custom.limitations?.created_at_lower_limit).toBeUndefined()
+    })
   })
 
   describe("Nip11Module", () => {

--- a/src/relay/core/nip/modules/Nip01Module.ts
+++ b/src/relay/core/nip/modules/Nip01Module.ts
@@ -5,7 +5,16 @@
  * This is the foundation module that every relay needs.
  */
 import { type NipModule, createModule } from "../NipModule.js"
-import { verifySignature, maxContentLength, maxTags } from "../../policy/BuiltInPolicies.js"
+import {
+  verifySignature,
+  maxContentLength,
+  maxTags,
+  maxFutureSeconds,
+  maxPastSeconds,
+} from "../../policy/BuiltInPolicies.js"
+import type { Policy } from "../../policy/Policy.js"
+import type { CryptoError, InvalidPublicKey } from "../../../../core/Errors.js"
+import type { EventService } from "../../../../services/EventService.js"
 
 // =============================================================================
 // Configuration
@@ -16,9 +25,28 @@ export interface Nip01Config {
   readonly maxContentLength?: number
   /** Maximum number of tags per event (default: 2000) */
   readonly maxTags?: number
+  /**
+   * Maximum seconds in the future for created_at (default: undefined = no limit)
+   * Events with created_at more than this many seconds in the future will be rejected.
+   * Reported in NIP-11 as created_at_upper_limit.
+   */
+  readonly maxFutureSeconds?: number
+  /**
+   * Maximum age of events in seconds (default: undefined = no limit)
+   * Events older than this many seconds will be rejected.
+   * Reported in NIP-11 as created_at_lower_limit.
+   */
+  readonly maxPastSeconds?: number
 }
 
-const DEFAULT_CONFIG: Required<Nip01Config> = {
+interface InternalConfig {
+  maxContentLength: number
+  maxTags: number
+  maxFutureSeconds?: number
+  maxPastSeconds?: number
+}
+
+const DEFAULT_CONFIG: InternalConfig = {
   maxContentLength: 64 * 1024, // 64KB
   maxTags: 2000,
 }
@@ -31,24 +59,49 @@ const DEFAULT_CONFIG: Required<Nip01Config> = {
  * Create NIP-01 module with optional configuration
  */
 export const createNip01Module = (config: Nip01Config = {}): NipModule => {
-  const cfg = { ...DEFAULT_CONFIG, ...config }
+  const cfg: InternalConfig = { ...DEFAULT_CONFIG, ...config }
+
+  // Build policy list - always include signature, content length, and tags
+  const policies: Policy<CryptoError | InvalidPublicKey, EventService>[] = [
+    verifySignature,
+    maxContentLength(cfg.maxContentLength),
+    maxTags(cfg.maxTags),
+  ]
+
+  // Add timestamp policies if configured
+  if (cfg.maxFutureSeconds !== undefined) {
+    policies.push(maxFutureSeconds(cfg.maxFutureSeconds))
+  }
+  if (cfg.maxPastSeconds !== undefined) {
+    policies.push(maxPastSeconds(cfg.maxPastSeconds))
+  }
+
+  // Build limitations object
+  const limitations: {
+    max_content_length: number
+    max_event_tags: number
+    created_at_lower_limit?: number
+    created_at_upper_limit?: number
+  } = {
+    max_content_length: cfg.maxContentLength,
+    max_event_tags: cfg.maxTags,
+  }
+
+  // Add timestamp limits to NIP-11 if configured
+  if (cfg.maxPastSeconds !== undefined) {
+    limitations.created_at_lower_limit = cfg.maxPastSeconds
+  }
+  if (cfg.maxFutureSeconds !== undefined) {
+    limitations.created_at_upper_limit = cfg.maxFutureSeconds
+  }
 
   return createModule({
     id: "nip-01",
     nips: [1],
     description: "Basic protocol flow: events, filters, subscriptions",
     kinds: [], // Applies to all kinds
-
-    policies: [
-      verifySignature,
-      maxContentLength(cfg.maxContentLength),
-      maxTags(cfg.maxTags),
-    ],
-
-    limitations: {
-      max_content_length: cfg.maxContentLength,
-      max_event_tags: cfg.maxTags,
-    },
+    policies,
+    limitations,
   })
 }
 


### PR DESCRIPTION
## Summary
- Add `maxFutureSeconds` and `maxPastSeconds` config options to `createNip01Module()`
- Timestamp policies automatically added when limits are configured
- Limits reported in NIP-11 relay info as `created_at_lower_limit` and `created_at_upper_limit`

## Usage
```typescript
const nip01 = createNip01Module({
  maxFutureSeconds: 60,      // Reject events >60s in future
  maxPastSeconds: 86400,     // Reject events >1 day old
})
```

## Test plan
- [x] `bun run verify` passes (280 tests)
- [x] New tests verify timestamp policy count
- [x] New tests verify NIP-11 limitation fields

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)