### PR TITLE
Relay: Add ConnectionManager for per-connection state

### DIFF
--- a/docs/BUILDOUT.md
+++ b/docs/BUILDOUT.md
@@ -35,7 +35,7 @@ src/
 - **Client**: RelayService (WebSocket connection management), FollowListService (NIP-02), RelayListService (NIP-65), HandlerService (NIP-89), DVMService (NIP-90)
 
 ### In Progress
-- None
+- **Relay**: #6 ConnectionManager (per-connection state)
 
 ### Open Issues
 

--- a/src/relay/core/ConnectionManager.test.ts
+++ b/src/relay/core/ConnectionManager.test.ts
@@ -1,0 +1,226 @@
+/**
+ * ConnectionManager Tests
+ */
+import { describe, it, expect } from "bun:test"
+import { Effect } from "effect"
+import { ConnectionManager, ConnectionManagerLive } from "./ConnectionManager.js"
+import type { PublicKey } from "../../core/Schema.js"
+
+const runWithManager = <A>(
+  effect: Effect.Effect<A, never, ConnectionManager>
+): Promise<A> => Effect.runPromise(Effect.provide(effect, ConnectionManagerLive))
+
+describe("ConnectionManager", () => {
+  describe("connect", () => {
+    it("should create a new connection context", async () => {
+      const result = await runWithManager(
+        Effect.gen(function* () {
+          const manager = yield* ConnectionManager
+          const ctx = yield* manager.connect({
+            id: "conn-1",
+            remoteAddress: "192.168.1.1",
+          })
+          return ctx
+        })
+      )
+
+      expect(result.id).toBe("conn-1")
+      expect(result.remoteAddress).toBe("192.168.1.1")
+      expect(result.connectedAt).toBeInstanceOf(Date)
+      expect(result.authPubkey).toBeUndefined()
+      expect(result.challenge).toBeUndefined()
+    })
+
+    it("should work without remote address", async () => {
+      const result = await runWithManager(
+        Effect.gen(function* () {
+          const manager = yield* ConnectionManager
+          const ctx = yield* manager.connect({ id: "conn-2" })
+          return ctx
+        })
+      )
+
+      expect(result.id).toBe("conn-2")
+      expect(result.remoteAddress).toBeUndefined()
+    })
+  })
+
+  describe("disconnect", () => {
+    it("should remove a connection", async () => {
+      const result = await runWithManager(
+        Effect.gen(function* () {
+          const manager = yield* ConnectionManager
+          yield* manager.connect({ id: "conn-1" })
+          yield* manager.disconnect("conn-1")
+          return yield* manager.get("conn-1")
+        })
+      )
+
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe("get", () => {
+    it("should return connection context if exists", async () => {
+      const result = await runWithManager(
+        Effect.gen(function* () {
+          const manager = yield* ConnectionManager
+          yield* manager.connect({ id: "conn-1", remoteAddress: "10.0.0.1" })
+          return yield* manager.get("conn-1")
+        })
+      )
+
+      expect(result?.id).toBe("conn-1")
+      expect(result?.remoteAddress).toBe("10.0.0.1")
+    })
+
+    it("should return undefined if connection does not exist", async () => {
+      const result = await runWithManager(
+        Effect.gen(function* () {
+          const manager = yield* ConnectionManager
+          return yield* manager.get("nonexistent")
+        })
+      )
+
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe("update", () => {
+    it("should update connection context", async () => {
+      const testPubkey = "abc123" as PublicKey
+
+      const result = await runWithManager(
+        Effect.gen(function* () {
+          const manager = yield* ConnectionManager
+          yield* manager.connect({ id: "conn-1" })
+          return yield* manager.update("conn-1", (ctx) => ({
+            ...ctx,
+            authPubkey: testPubkey,
+          }))
+        })
+      )
+
+      expect(result?.authPubkey).toBe(testPubkey)
+    })
+
+    it("should return undefined if connection does not exist", async () => {
+      const result = await runWithManager(
+        Effect.gen(function* () {
+          const manager = yield* ConnectionManager
+          return yield* manager.update("nonexistent", (ctx) => ctx)
+        })
+      )
+
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe("setChallenge", () => {
+    it("should set NIP-42 challenge", async () => {
+      const result = await runWithManager(
+        Effect.gen(function* () {
+          const manager = yield* ConnectionManager
+          yield* manager.connect({ id: "conn-1" })
+          yield* manager.setChallenge("conn-1", "challenge-string")
+          return yield* manager.get("conn-1")
+        })
+      )
+
+      expect(result?.challenge).toBe("challenge-string")
+    })
+  })
+
+  describe("setAuthPubkey", () => {
+    it("should set authenticated pubkey", async () => {
+      const testPubkey = "pubkey123" as PublicKey
+
+      const result = await runWithManager(
+        Effect.gen(function* () {
+          const manager = yield* ConnectionManager
+          yield* manager.connect({ id: "conn-1" })
+          yield* manager.setAuthPubkey("conn-1", testPubkey)
+          return yield* manager.get("conn-1")
+        })
+      )
+
+      expect(result?.authPubkey).toBe(testPubkey)
+    })
+  })
+
+  describe("isAuthenticated", () => {
+    it("should return false for unauthenticated connection", async () => {
+      const result = await runWithManager(
+        Effect.gen(function* () {
+          const manager = yield* ConnectionManager
+          yield* manager.connect({ id: "conn-1" })
+          return yield* manager.isAuthenticated("conn-1")
+        })
+      )
+
+      expect(result).toBe(false)
+    })
+
+    it("should return true after setting authPubkey", async () => {
+      const testPubkey = "pubkey123" as PublicKey
+
+      const result = await runWithManager(
+        Effect.gen(function* () {
+          const manager = yield* ConnectionManager
+          yield* manager.connect({ id: "conn-1" })
+          yield* manager.setAuthPubkey("conn-1", testPubkey)
+          return yield* manager.isAuthenticated("conn-1")
+        })
+      )
+
+      expect(result).toBe(true)
+    })
+
+    it("should return false for nonexistent connection", async () => {
+      const result = await runWithManager(
+        Effect.gen(function* () {
+          const manager = yield* ConnectionManager
+          return yield* manager.isAuthenticated("nonexistent")
+        })
+      )
+
+      expect(result).toBe(false)
+    })
+  })
+
+  describe("getAll", () => {
+    it("should return all connections", async () => {
+      const result = await runWithManager(
+        Effect.gen(function* () {
+          const manager = yield* ConnectionManager
+          yield* manager.connect({ id: "conn-1" })
+          yield* manager.connect({ id: "conn-2" })
+          yield* manager.connect({ id: "conn-3" })
+          return yield* manager.getAll()
+        })
+      )
+
+      expect(result.length).toBe(3)
+      expect(result.map((c) => c.id).sort()).toEqual(["conn-1", "conn-2", "conn-3"])
+    })
+  })
+
+  describe("count", () => {
+    it("should return connection count", async () => {
+      const result = await runWithManager(
+        Effect.gen(function* () {
+          const manager = yield* ConnectionManager
+          yield* manager.connect({ id: "conn-1" })
+          yield* manager.connect({ id: "conn-2" })
+          const count1 = yield* manager.count()
+          yield* manager.disconnect("conn-1")
+          const count2 = yield* manager.count()
+          return { count1, count2 }
+        })
+      )
+
+      expect(result.count1).toBe(2)
+      expect(result.count2).toBe(1)
+    })
+  })
+})

--- a/src/relay/core/ConnectionManager.ts
+++ b/src/relay/core/ConnectionManager.ts
@@ -1,0 +1,187 @@
+/**
+ * ConnectionManager
+ *
+ * Tracks per-connection state for WebSocket connections.
+ * Used for authentication (NIP-42), rate limiting, and connection metadata.
+ */
+import { Context, Effect, Layer, Ref } from "effect"
+import type { PublicKey } from "../../core/Schema.js"
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/**
+ * Per-connection state
+ */
+export interface ConnectionContext {
+  /** Unique connection identifier */
+  readonly id: string
+  /** Remote client IP address (if available) */
+  readonly remoteAddress?: string
+  /** When the connection was established */
+  readonly connectedAt: Date
+  /** NIP-42: Authenticated pubkey (set after successful AUTH) */
+  readonly authPubkey?: PublicKey
+  /** NIP-42: Challenge string sent to client */
+  readonly challenge?: string
+}
+
+/**
+ * Options for creating a new connection
+ */
+export interface ConnectionOptions {
+  readonly id: string
+  readonly remoteAddress?: string
+}
+
+// =============================================================================
+// Service Interface
+// =============================================================================
+
+export interface ConnectionManager {
+  readonly _tag: "ConnectionManager"
+
+  /**
+   * Register a new connection
+   */
+  connect(options: ConnectionOptions): Effect.Effect<ConnectionContext>
+
+  /**
+   * Remove a connection (on disconnect)
+   */
+  disconnect(connectionId: string): Effect.Effect<void>
+
+  /**
+   * Get connection context by ID
+   */
+  get(connectionId: string): Effect.Effect<ConnectionContext | undefined>
+
+  /**
+   * Update connection context (e.g., after AUTH)
+   */
+  update(
+    connectionId: string,
+    updater: (ctx: ConnectionContext) => ConnectionContext
+  ): Effect.Effect<ConnectionContext | undefined>
+
+  /**
+   * Set NIP-42 challenge for a connection
+   */
+  setChallenge(connectionId: string, challenge: string): Effect.Effect<void>
+
+  /**
+   * Set authenticated pubkey after successful NIP-42 AUTH
+   */
+  setAuthPubkey(connectionId: string, pubkey: PublicKey): Effect.Effect<void>
+
+  /**
+   * Check if a connection is authenticated
+   */
+  isAuthenticated(connectionId: string): Effect.Effect<boolean>
+
+  /**
+   * Get all active connections
+   */
+  getAll(): Effect.Effect<readonly ConnectionContext[]>
+
+  /**
+   * Get connection count (for metrics)
+   */
+  count(): Effect.Effect<number>
+}
+
+// =============================================================================
+// Service Tag
+// =============================================================================
+
+export const ConnectionManager = Context.GenericTag<ConnectionManager>("ConnectionManager")
+
+// =============================================================================
+// In-Memory Implementation
+// =============================================================================
+
+type ConnectionMap = Map<string, ConnectionContext>
+
+const makeConnectionManager = (
+  connectionsRef: Ref.Ref<ConnectionMap>
+): ConnectionManager => ({
+  _tag: "ConnectionManager",
+
+  connect: (options) =>
+    Ref.modify(connectionsRef, (conns) => {
+      const ctx: ConnectionContext = {
+        id: options.id,
+        connectedAt: new Date(),
+        ...(options.remoteAddress !== undefined && { remoteAddress: options.remoteAddress }),
+      }
+      const updated = new Map(conns)
+      updated.set(options.id, ctx)
+      return [ctx, updated]
+    }),
+
+  disconnect: (connectionId) =>
+    Ref.update(connectionsRef, (conns) => {
+      const updated = new Map(conns)
+      updated.delete(connectionId)
+      return updated
+    }),
+
+  get: (connectionId) =>
+    Ref.get(connectionsRef).pipe(Effect.map((conns) => conns.get(connectionId))),
+
+  update: (connectionId, updater) =>
+    Ref.modify(connectionsRef, (conns) => {
+      const existing = conns.get(connectionId)
+      if (!existing) {
+        return [undefined, conns]
+      }
+      const updated = new Map(conns)
+      const newCtx = updater(existing)
+      updated.set(connectionId, newCtx)
+      return [newCtx, updated]
+    }),
+
+  setChallenge: (connectionId, challenge) =>
+    Ref.update(connectionsRef, (conns) => {
+      const existing = conns.get(connectionId)
+      if (!existing) return conns
+      const updated = new Map(conns)
+      updated.set(connectionId, { ...existing, challenge })
+      return updated
+    }),
+
+  setAuthPubkey: (connectionId, pubkey) =>
+    Ref.update(connectionsRef, (conns) => {
+      const existing = conns.get(connectionId)
+      if (!existing) return conns
+      const updated = new Map(conns)
+      updated.set(connectionId, { ...existing, authPubkey: pubkey })
+      return updated
+    }),
+
+  isAuthenticated: (connectionId) =>
+    Ref.get(connectionsRef).pipe(
+      Effect.map((conns) => {
+        const ctx = conns.get(connectionId)
+        return ctx?.authPubkey !== undefined
+      })
+    ),
+
+  getAll: () =>
+    Ref.get(connectionsRef).pipe(Effect.map((conns) => Array.from(conns.values()))),
+
+  count: () => Ref.get(connectionsRef).pipe(Effect.map((conns) => conns.size)),
+})
+
+// =============================================================================
+// Service Layer
+// =============================================================================
+
+/**
+ * In-memory ConnectionManager layer
+ */
+export const ConnectionManagerLive = Layer.effect(
+  ConnectionManager,
+  Ref.make<ConnectionMap>(new Map()).pipe(Effect.map(makeConnectionManager))
+)

--- a/src/relay/core/index.ts
+++ b/src/relay/core/index.ts
@@ -21,6 +21,14 @@ export {
   type Subscription,
 } from "./SubscriptionManager.js"
 
+// Connection management
+export {
+  ConnectionManager,
+  ConnectionManagerLive,
+  type ConnectionContext,
+  type ConnectionOptions,
+} from "./ConnectionManager.js"
+
 // Filter matching
 export { matchesFilter, matchesFilters } from "./FilterMatcher.js"
 


### PR DESCRIPTION
## Summary
- Add `ConnectionManager` service for tracking per-connection state
- `ConnectionContext`: id, remoteAddress, connectedAt, authPubkey, challenge
- NIP-42 ready methods: `setChallenge()`, `setAuthPubkey()`, `isAuthenticated()`

## API
```typescript
// Connect
const ctx = yield* connectionManager.connect({ id: "conn-1", remoteAddress: "10.0.0.1" })

// NIP-42 flow
yield* connectionManager.setChallenge(connectionId, challengeString)
yield* connectionManager.setAuthPubkey(connectionId, pubkey)
const authed = yield* connectionManager.isAuthenticated(connectionId)
```

## Test plan
- [x] `bun run verify` passes (294 tests)
- [x] 14 new tests for ConnectionManager operations

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)