### PR TITLE
Relay: NIP-42 Authentication

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,10 @@ Default to using Bun instead of Node.js.
 - Prefer `Bun.file` over `node:fs`'s readFile/writeFile
 - Bun.$`ls` instead of execa.
 
+## Code Style
+
+- **Never use inline/dynamic imports** - All imports must be at the top of the file. Do not use `import()` expressions or inline type imports like `options.value as import("./module").Type`. Import the type at the top of the file instead.
+
 ## Testing
 
 Use `bun test` to run tests.

--- a/docs/BUILDOUT.md
+++ b/docs/BUILDOUT.md
@@ -30,12 +30,9 @@ src/
 ### Completed
 - **Core**: Schema.ts (NIP-01 types), Errors.ts, Nip19.ts (bech32 encoding)
 - **Services**: CryptoService, EventService, Nip44Service (NIP-44 versioned encryption)
-- **Relay**: EventStore, SubscriptionManager, MessageHandler, RelayServer, PolicyPipeline, NIP-16/33 Replaceable Events, NIP-11 Relay Info, NIP Module System, Timestamp Limits
+- **Relay**: EventStore, SubscriptionManager, MessageHandler, RelayServer, PolicyPipeline, NIP-16/33 Replaceable Events, NIP-11 Relay Info, NIP Module System, Timestamp Limits, ConnectionManager, NIP-42 Authentication (AuthService)
 - **Relay Backends**: Bun (SQLite), Cloudflare Durable Objects (DO SQLite)
 - **Client**: RelayService (WebSocket connection management), FollowListService (NIP-02), RelayListService (NIP-65), HandlerService (NIP-89), DVMService (NIP-90)
-
-### In Progress
-- **Relay**: #6 ConnectionManager (per-connection state)
 
 ### Open Issues
 
@@ -43,13 +40,13 @@ src/
 | Issue | Description |
 |-------|-------------|
 | ~~#5~~ | ~~NIP Module system~~ ✅ |
-| #6 | ConnectionManager |
+| ~~#6~~ | ~~ConnectionManager~~ ✅ |
 | #7 | NIP-09 Deletion |
 | ~~#8~~ | ~~NIP-11 Relay Info~~ ✅ |
 | ~~#9~~ | ~~NIP-16/33 Replaceable Events~~ ✅ |
 | ~~#10~~ | ~~Timestamp Limits (NIP-11 limitation)~~ ✅ |
 | #11 | NIP-40 Expiration |
-| #12 | NIP-42 Authentication |
+| ~~#12~~ | ~~NIP-42 Authentication~~ ✅ |
 | #13 | Rate Limiting |
 
 **Client (#14-24)**
@@ -103,8 +100,8 @@ src/
 | Order | Relay | Client | Notes |
 |-------|-------|--------|-------|
 | 4.1 | - | ✅ #19: NIP-44 | Modern encryption for DMs |
-| 4.2 | #6: ConnectionManager | - | Per-connection state |
-| 4.3 | #12: NIP-42 Auth | - | Requires ConnectionManager |
+| 4.2 | ✅ #6: ConnectionManager | - | Per-connection state |
+| 4.3 | ✅ #12: NIP-42 Auth | - | Requires ConnectionManager |
 
 ### Phase 5: Advanced
 **Goal**: Production-ready features
@@ -208,6 +205,7 @@ src/client/
 |-----|----------------------|---------------|--------|
 | NIP-01 Filters | `filter.test.ts` | `src/relay/FilterMatcher.test.ts` | ✅ Done |
 | NIP-19 | `nip19.test.ts` | `src/core/Nip19.test.ts` | ✅ Done |
+| NIP-42 | `nip42.test.ts` | `src/relay/core/nip/modules/Nip42Module.test.ts` | ✅ Done |
 | NIP-44 | `nip44.test.ts` + vectors | `src/services/Nip44Service.test.ts` | ✅ Done |
 | NIP-04 | `nip04.test.ts` | - | ⬜ Not planned |
 | NIP-05 | `nip05.test.ts` | `src/client/Nip05Service.test.ts` | ⬜ Not started |

--- a/src/core/Schema.ts
+++ b/src/core/Schema.ts
@@ -150,11 +150,19 @@ export const ClientCloseMessage = Schema.Tuple(
 )
 export type ClientCloseMessage = typeof ClientCloseMessage.Type
 
+/** AUTH message: client authentication (NIP-42) */
+export const ClientAuthMessage = Schema.Tuple(
+  Schema.Literal("AUTH"),
+  NostrEvent // kind 22242 signed event
+)
+export type ClientAuthMessage = typeof ClientAuthMessage.Type
+
 /** All client message types */
 export const ClientMessage = Schema.Union(
   ClientEventMessage,
   ClientReqMessage,
-  ClientCloseMessage
+  ClientCloseMessage,
+  ClientAuthMessage
 )
 export type ClientMessage = typeof ClientMessage.Type
 
@@ -201,15 +209,30 @@ export const RelayNoticeMessage = Schema.Tuple(
 )
 export type RelayNoticeMessage = typeof RelayNoticeMessage.Type
 
+/** AUTH message: authentication challenge (NIP-42) */
+export const RelayAuthMessage = Schema.Tuple(
+  Schema.Literal("AUTH"),
+  Schema.String // challenge string
+)
+export type RelayAuthMessage = typeof RelayAuthMessage.Type
+
 /** All relay message types */
 export const RelayMessage = Schema.Union(
   RelayEventMessage,
   RelayOkMessage,
   RelayEoseMessage,
   RelayClosedMessage,
-  RelayNoticeMessage
+  RelayNoticeMessage,
+  RelayAuthMessage
 )
 export type RelayMessage = typeof RelayMessage.Type
+
+// =============================================================================
+// NIP-42 Auth Event Kind
+// =============================================================================
+
+/** Auth event kind (NIP-42) */
+export const AUTH_EVENT_KIND = 22242 as EventKind
 
 // =============================================================================
 // Event Kind Classification (NIP-16/33)

--- a/src/relay/core/AuthService.test.ts
+++ b/src/relay/core/AuthService.test.ts
@@ -1,0 +1,343 @@
+/**
+ * AuthService Tests
+ */
+import { describe, it, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import { AuthService, makeAuthServiceLayer } from "./AuthService.js"
+import { ConnectionManager, ConnectionManagerLive } from "./ConnectionManager.js"
+import { EventService, EventServiceLive } from "../../services/EventService.js"
+import { CryptoServiceLive } from "../../services/CryptoService.js"
+import {
+  type EventKind,
+  type PrivateKey,
+  type Tag,
+  type UnixTimestamp,
+  AUTH_EVENT_KIND,
+} from "../../core/Schema.js"
+import type { Nip42Config } from "./nip/modules/Nip42Module.js"
+
+// Test helpers
+const testPrivateKey = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" as PrivateKey
+
+const testConfig: Nip42Config = {
+  relayUrls: ["wss://relay.test.com"],
+  maxAuthAge: 600,
+}
+
+const makeTestLayer = (config: Nip42Config = testConfig) => {
+  const authServiceLayer = makeAuthServiceLayer(config)
+  const cryptoLayer = CryptoServiceLive
+  const eventLayer = Layer.provide(EventServiceLive, cryptoLayer)
+  const connLayer = ConnectionManagerLive
+
+  return Layer.provide(
+    authServiceLayer,
+    Layer.merge(eventLayer, connLayer)
+  )
+}
+
+const runWithAuth = <A, E>(
+  effect: Effect.Effect<A, E, AuthService | ConnectionManager>
+): Promise<A> => {
+  const layer = makeTestLayer()
+  const fullLayer = Layer.merge(layer, ConnectionManagerLive)
+  return Effect.runPromise(Effect.provide(effect, fullLayer)) as Promise<A>
+}
+
+const createTestAuthEvent = async (
+  challenge: string,
+  relayUrl: string,
+  options: { createdAt?: number; kind?: number } = {}
+) => {
+  const layer = Layer.provide(EventServiceLive, CryptoServiceLive)
+  const kind = (options.kind ?? AUTH_EVENT_KIND) as EventKind
+
+  const params: {
+    kind: EventKind
+    tags: Tag[]
+    content: string
+    created_at?: UnixTimestamp
+  } = {
+    kind,
+    tags: [
+      ["relay", relayUrl] as unknown as Tag,
+      ["challenge", challenge] as unknown as Tag,
+    ],
+    content: "",
+  }
+
+  if (options.createdAt !== undefined) {
+    params.created_at = options.createdAt as UnixTimestamp
+  }
+
+  return await Effect.runPromise(
+    Effect.provide(
+      Effect.gen(function* () {
+        const eventService = yield* EventService
+        return yield* eventService.createEvent(params, testPrivateKey)
+      }),
+      layer
+    )
+  )
+}
+
+describe("AuthService", () => {
+  describe("getChallenge", () => {
+    it("should create a challenge for a new connection", async () => {
+      const result = await runWithAuth(
+        Effect.gen(function* () {
+          const connectionManager = yield* ConnectionManager
+          const authService = yield* AuthService
+
+          yield* connectionManager.connect({ id: "conn-1" })
+          return yield* authService.getChallenge("conn-1")
+        })
+      )
+
+      expect(result).toBeDefined()
+      expect(result.length).toBeGreaterThan(0)
+    })
+
+    it("should return same challenge for existing connection", async () => {
+      const result = await runWithAuth(
+        Effect.gen(function* () {
+          const connectionManager = yield* ConnectionManager
+          const authService = yield* AuthService
+
+          yield* connectionManager.connect({ id: "conn-1" })
+          const c1 = yield* authService.getChallenge("conn-1")
+          const c2 = yield* authService.getChallenge("conn-1")
+          return { c1, c2 }
+        })
+      )
+
+      expect(result.c1).toBe(result.c2)
+    })
+  })
+
+  describe("createChallenge", () => {
+    it("should create a new challenge even if one exists", async () => {
+      const result = await runWithAuth(
+        Effect.gen(function* () {
+          const connectionManager = yield* ConnectionManager
+          const authService = yield* AuthService
+
+          yield* connectionManager.connect({ id: "conn-1" })
+          const c1 = yield* authService.createChallenge("conn-1")
+          const c2 = yield* authService.createChallenge("conn-1")
+          return { c1, c2 }
+        })
+      )
+
+      expect(result.c1).not.toBe(result.c2)
+    })
+  })
+
+  describe("handleAuth", () => {
+    it("should authenticate valid auth event", async () => {
+      const layer = makeTestLayer()
+      const fullLayer = Layer.merge(layer, ConnectionManagerLive)
+
+      const result = await Effect.runPromise(
+        Effect.provide(
+          Effect.gen(function* () {
+            const connectionManager = yield* ConnectionManager
+            const authService = yield* AuthService
+
+            yield* connectionManager.connect({ id: "conn-1" })
+            const challenge = yield* authService.createChallenge("conn-1")
+
+            const authEvent = yield* Effect.promise(() =>
+              createTestAuthEvent(challenge, "wss://relay.test.com")
+            )
+
+            return yield* authService.handleAuth("conn-1", authEvent)
+          }),
+          fullLayer
+        )
+      )
+
+      expect(result.success).toBe(true)
+      expect(result.pubkey).toBeDefined()
+      expect(result.message).toBe("")
+    })
+
+    it("should reject auth event with wrong challenge", async () => {
+      const layer = makeTestLayer()
+      const fullLayer = Layer.merge(layer, ConnectionManagerLive)
+
+      const result = await Effect.runPromise(
+        Effect.provide(
+          Effect.gen(function* () {
+            const connectionManager = yield* ConnectionManager
+            const authService = yield* AuthService
+
+            yield* connectionManager.connect({ id: "conn-1" })
+            yield* authService.createChallenge("conn-1")
+
+            const authEvent = yield* Effect.promise(() =>
+              createTestAuthEvent("wrong-challenge", "wss://relay.test.com")
+            )
+
+            return yield* authService.handleAuth("conn-1", authEvent)
+          }),
+          fullLayer
+        )
+      )
+
+      expect(result.success).toBe(false)
+      expect(result.message).toContain("challenge mismatch")
+    })
+
+    it("should reject auth event for unknown connection", async () => {
+      const layer = makeTestLayer()
+      const fullLayer = Layer.merge(layer, ConnectionManagerLive)
+
+      const result = await Effect.runPromise(
+        Effect.provide(
+          Effect.gen(function* () {
+            const authService = yield* AuthService
+
+            const authEvent = yield* Effect.promise(() =>
+              createTestAuthEvent("some-challenge", "wss://relay.test.com")
+            )
+
+            return yield* authService.handleAuth("unknown-conn", authEvent)
+          }),
+          fullLayer
+        )
+      )
+
+      expect(result.success).toBe(false)
+      expect(result.message).toContain("connection not found")
+    })
+
+    it("should reject auth event when no challenge issued", async () => {
+      const layer = makeTestLayer()
+      const fullLayer = Layer.merge(layer, ConnectionManagerLive)
+
+      const result = await Effect.runPromise(
+        Effect.provide(
+          Effect.gen(function* () {
+            const connectionManager = yield* ConnectionManager
+            const authService = yield* AuthService
+
+            yield* connectionManager.connect({ id: "conn-1" })
+            // Note: not calling createChallenge
+
+            const authEvent = yield* Effect.promise(() =>
+              createTestAuthEvent("some-challenge", "wss://relay.test.com")
+            )
+
+            return yield* authService.handleAuth("conn-1", authEvent)
+          }),
+          fullLayer
+        )
+      )
+
+      expect(result.success).toBe(false)
+      expect(result.message).toContain("no challenge issued")
+    })
+  })
+
+  describe("isAuthenticated", () => {
+    it("should return false for unauthenticated connection", async () => {
+      const result = await runWithAuth(
+        Effect.gen(function* () {
+          const connectionManager = yield* ConnectionManager
+          const authService = yield* AuthService
+
+          yield* connectionManager.connect({ id: "conn-1" })
+          return yield* authService.isAuthenticated("conn-1")
+        })
+      )
+
+      expect(result).toBe(false)
+    })
+
+    it("should return true after successful authentication", async () => {
+      const layer = makeTestLayer()
+      const fullLayer = Layer.merge(layer, ConnectionManagerLive)
+
+      const result = await Effect.runPromise(
+        Effect.provide(
+          Effect.gen(function* () {
+            const connectionManager = yield* ConnectionManager
+            const authService = yield* AuthService
+
+            yield* connectionManager.connect({ id: "conn-1" })
+            const challenge = yield* authService.createChallenge("conn-1")
+
+            const authEvent = yield* Effect.promise(() =>
+              createTestAuthEvent(challenge, "wss://relay.test.com")
+            )
+
+            yield* authService.handleAuth("conn-1", authEvent)
+            return yield* authService.isAuthenticated("conn-1")
+          }),
+          fullLayer
+        )
+      )
+
+      expect(result).toBe(true)
+    })
+  })
+
+  describe("getAuthPubkey", () => {
+    it("should return undefined for unauthenticated connection", async () => {
+      const result = await runWithAuth(
+        Effect.gen(function* () {
+          const connectionManager = yield* ConnectionManager
+          const authService = yield* AuthService
+
+          yield* connectionManager.connect({ id: "conn-1" })
+          return yield* authService.getAuthPubkey("conn-1")
+        })
+      )
+
+      expect(result).toBeUndefined()
+    })
+
+    it("should return pubkey after authentication", async () => {
+      const layer = makeTestLayer()
+      const fullLayer = Layer.merge(layer, ConnectionManagerLive)
+
+      const result = await Effect.runPromise(
+        Effect.provide(
+          Effect.gen(function* () {
+            const connectionManager = yield* ConnectionManager
+            const authService = yield* AuthService
+
+            yield* connectionManager.connect({ id: "conn-1" })
+            const challenge = yield* authService.createChallenge("conn-1")
+
+            const authEvent = yield* Effect.promise(() =>
+              createTestAuthEvent(challenge, "wss://relay.test.com")
+            )
+
+            const authResult = yield* authService.handleAuth("conn-1", authEvent)
+            const storedPubkey = yield* authService.getAuthPubkey("conn-1")
+            return { authPubkey: authResult.pubkey, storedPubkey }
+          }),
+          fullLayer
+        )
+      )
+
+      expect(result.storedPubkey).toBeDefined()
+      expect(String(result.storedPubkey)).toBe(String(result.authPubkey))
+    })
+  })
+
+  describe("buildAuthMessage", () => {
+    it("should build correct AUTH message format", async () => {
+      const result = await runWithAuth(
+        Effect.gen(function* () {
+          const authService = yield* AuthService
+          return authService.buildAuthMessage("test-challenge")
+        })
+      )
+
+      expect(result).toEqual(["AUTH", "test-challenge"])
+    })
+  })
+})

--- a/src/relay/core/AuthService.ts
+++ b/src/relay/core/AuthService.ts
@@ -1,0 +1,176 @@
+/**
+ * AuthService
+ *
+ * NIP-42 authentication service that integrates with ConnectionManager.
+ * Handles challenge generation, storage, and auth event verification.
+ */
+import { Context, Effect, Layer } from "effect"
+import { ConnectionManager } from "./ConnectionManager.js"
+import { EventService } from "../../services/EventService.js"
+import { verifyAuthEvent, generateChallenge, type Nip42Config } from "./nip/modules/Nip42Module.js"
+import type { NostrEvent, PublicKey, RelayMessage } from "../../core/Schema.js"
+import type { CryptoError, InvalidPublicKey } from "../../core/Errors.js"
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface AuthResult {
+  readonly success: boolean
+  readonly pubkey?: PublicKey
+  readonly message: string
+}
+
+// =============================================================================
+// Service Interface
+// =============================================================================
+
+export interface AuthService {
+  readonly _tag: "AuthService"
+
+  /**
+   * Get or create a challenge for a connection
+   * If a challenge already exists, returns it; otherwise creates a new one
+   */
+  getChallenge(connectionId: string): Effect.Effect<string>
+
+  /**
+   * Create a new challenge for a connection (replacing any existing one)
+   */
+  createChallenge(connectionId: string): Effect.Effect<string>
+
+  /**
+   * Handle an AUTH message from a client
+   * Verifies the auth event and updates connection state if valid
+   */
+  handleAuth(
+    connectionId: string,
+    authEvent: NostrEvent
+  ): Effect.Effect<AuthResult, CryptoError | InvalidPublicKey>
+
+  /**
+   * Check if a connection is authenticated
+   */
+  isAuthenticated(connectionId: string): Effect.Effect<boolean>
+
+  /**
+   * Get the authenticated pubkey for a connection (if any)
+   */
+  getAuthPubkey(connectionId: string): Effect.Effect<PublicKey | undefined>
+
+  /**
+   * Build an AUTH challenge message to send to the client
+   */
+  buildAuthMessage(challenge: string): RelayMessage
+}
+
+// =============================================================================
+// Service Tag
+// =============================================================================
+
+export const AuthService = Context.GenericTag<AuthService>("AuthService")
+
+// =============================================================================
+// Service Implementation
+// =============================================================================
+
+const make = (config: Nip42Config) =>
+  Effect.gen(function* () {
+    const connectionManager = yield* ConnectionManager
+    const eventService = yield* EventService
+
+    const getChallenge: AuthService["getChallenge"] = (connectionId) =>
+      Effect.gen(function* () {
+        const conn = yield* connectionManager.get(connectionId)
+        if (conn?.challenge) {
+          return conn.challenge
+        }
+        // Create a new challenge
+        const challenge = generateChallenge()
+        yield* connectionManager.setChallenge(connectionId, challenge)
+        return challenge
+      })
+
+    const createChallenge: AuthService["createChallenge"] = (connectionId) =>
+      Effect.gen(function* () {
+        const challenge = generateChallenge()
+        yield* connectionManager.setChallenge(connectionId, challenge)
+        return challenge
+      })
+
+    const handleAuth: AuthService["handleAuth"] = (connectionId, authEvent) =>
+      Effect.gen(function* () {
+        // Get the connection's challenge
+        const conn = yield* connectionManager.get(connectionId)
+        if (!conn) {
+          return {
+            success: false,
+            message: "error: connection not found",
+          }
+        }
+
+        if (!conn.challenge) {
+          return {
+            success: false,
+            message: "error: no challenge issued for this connection",
+          }
+        }
+
+        // Verify the auth event
+        const result = yield* verifyAuthEvent(
+          authEvent,
+          conn.challenge,
+          config.relayUrls,
+          config.maxAuthAge ?? 600
+        ).pipe(Effect.provideService(EventService, eventService))
+
+        if (!result.valid) {
+          return {
+            success: false,
+            message: result.error ?? "auth-required: invalid auth event",
+          }
+        }
+
+        // Set the authenticated pubkey on the connection
+        const pubkey = result.pubkey!
+        yield* connectionManager.setAuthPubkey(connectionId, pubkey)
+
+        return {
+          success: true,
+          pubkey,
+          message: "",
+        }
+      })
+
+    const isAuthenticated: AuthService["isAuthenticated"] = (connectionId) =>
+      connectionManager.isAuthenticated(connectionId)
+
+    const getAuthPubkey: AuthService["getAuthPubkey"] = (connectionId) =>
+      Effect.gen(function* () {
+        const conn = yield* connectionManager.get(connectionId)
+        return conn?.authPubkey
+      })
+
+    const buildAuthMessage: AuthService["buildAuthMessage"] = (challenge) =>
+      ["AUTH", challenge] as RelayMessage
+
+    return {
+      _tag: "AuthService" as const,
+      getChallenge,
+      createChallenge,
+      handleAuth,
+      isAuthenticated,
+      getAuthPubkey,
+      buildAuthMessage,
+    }
+  })
+
+// =============================================================================
+// Service Layer
+// =============================================================================
+
+/**
+ * Create AuthService layer with NIP-42 configuration
+ */
+export const makeAuthServiceLayer = (config: Nip42Config) =>
+  Layer.effect(AuthService, make(config))

--- a/src/relay/core/index.ts
+++ b/src/relay/core/index.ts
@@ -10,6 +10,7 @@ export {
   MessageHandler,
   MessageHandlerLive,
   MessageHandlerWithRegistry,
+  MessageHandlerWithAuth,
   type HandleResult,
   type BroadcastMessage,
 } from "./MessageHandler.js"
@@ -28,6 +29,13 @@ export {
   type ConnectionContext,
   type ConnectionOptions,
 } from "./ConnectionManager.js"
+
+// Authentication (NIP-42)
+export {
+  AuthService,
+  makeAuthServiceLayer,
+  type AuthResult,
+} from "./AuthService.js"
 
 // Filter matching
 export { matchesFilter, matchesFilters } from "./FilterMatcher.js"

--- a/src/relay/core/nip/modules/Nip42Module.test.ts
+++ b/src/relay/core/nip/modules/Nip42Module.test.ts
@@ -1,0 +1,279 @@
+/**
+ * NIP-42 Module Tests
+ */
+import { describe, it, expect } from "bun:test"
+import { Effect, Layer } from "effect"
+import {
+  verifyAuthEvent,
+  generateChallenge,
+  createNip42Module,
+} from "./Nip42Module.js"
+import { EventService, EventServiceLive } from "../../../../services/EventService.js"
+import { CryptoServiceLive } from "../../../../services/CryptoService.js"
+import {
+  type NostrEvent,
+  type EventKind,
+  type PrivateKey,
+  type Tag,
+  type UnixTimestamp,
+  AUTH_EVENT_KIND,
+} from "../../../../core/Schema.js"
+import type { PolicyDecision } from "../../policy/Policy.js"
+
+// Test helpers
+const testPrivateKey = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef" as PrivateKey
+
+const runWithServices = <A, E>(
+  effect: Effect.Effect<A, E, EventService>
+): Promise<A> => {
+  const layer = Layer.provide(EventServiceLive, CryptoServiceLive)
+  return Effect.runPromise(Effect.provide(effect, layer)) as Promise<A>
+}
+
+const createAuthEvent = async (
+  challenge: string,
+  relayUrl: string,
+  options: {
+    privateKey?: PrivateKey
+    kind?: number
+    createdAt?: number
+  } = {}
+): Promise<NostrEvent> => {
+  const layer = Layer.provide(EventServiceLive, CryptoServiceLive)
+
+  const privKey = options.privateKey ?? testPrivateKey
+  const kind = (options.kind ?? AUTH_EVENT_KIND) as EventKind
+
+  const params: {
+    kind: EventKind
+    tags: Tag[]
+    content: string
+    created_at?: UnixTimestamp
+  } = {
+    kind,
+    tags: [
+      ["relay", relayUrl] as unknown as Tag,
+      ["challenge", challenge] as unknown as Tag,
+    ],
+    content: "",
+  }
+
+  if (options.createdAt !== undefined) {
+    params.created_at = options.createdAt as UnixTimestamp
+  }
+
+  return Effect.runPromise(
+    Effect.provide(
+      Effect.gen(function* () {
+        const eventService = yield* EventService
+        return yield* eventService.createEvent(params, privKey)
+      }),
+      layer
+    )
+  )
+}
+
+describe("Nip42Module", () => {
+  describe("generateChallenge", () => {
+    it("should generate a unique challenge string", () => {
+      const c1 = generateChallenge()
+      const c2 = generateChallenge()
+      expect(c1).not.toBe(c2)
+      expect(c1.length).toBeGreaterThan(0)
+    })
+  })
+
+  // Test parity with nostr-tools nip42.test.ts
+  describe("auth event format (nostr-tools parity)", () => {
+    it("should create auth event with correct format", async () => {
+      const relayUrl = "wss://relay.example.com/"
+      const challenge = "chachacha"
+      const event = await createAuthEvent(challenge, relayUrl)
+
+      // Matches nostr-tools nip42.test.ts assertions
+      expect(event.tags).toHaveLength(2)
+      const tag0 = event.tags[0]!
+      const tag1 = event.tags[1]!
+      expect(tag0[0]).toBe("relay")
+      expect(tag0[1]).toBe(relayUrl)
+      expect(tag1[0]).toBe("challenge")
+      expect(tag1[1]).toBe(challenge)
+      expect(event.kind as number).toBe(22242)
+    })
+  })
+
+  describe("verifyAuthEvent", () => {
+    const relayUrls = ["wss://relay.example.com"]
+    const maxAuthAge = 600 // 10 minutes
+
+    it("should accept valid auth event", async () => {
+      const challenge = generateChallenge()
+      const event = await createAuthEvent(challenge, "wss://relay.example.com")
+
+      const result = await runWithServices(
+        verifyAuthEvent(event, challenge, relayUrls, maxAuthAge)
+      )
+
+      expect(result.valid).toBe(true)
+      expect(result.pubkey).toBeDefined()
+    })
+
+    it("should reject wrong kind", async () => {
+      const challenge = generateChallenge()
+      const event = await createAuthEvent(challenge, "wss://relay.example.com", {
+        kind: 1, // Wrong kind
+      })
+
+      const result = await runWithServices(
+        verifyAuthEvent(event, challenge, relayUrls, maxAuthAge)
+      )
+
+      expect(result.valid).toBe(false)
+      expect(result.error).toContain("expected kind 22242")
+    })
+
+    it("should reject challenge mismatch", async () => {
+      const challenge = generateChallenge()
+      const wrongChallenge = generateChallenge()
+      const event = await createAuthEvent(challenge, "wss://relay.example.com")
+
+      const result = await runWithServices(
+        verifyAuthEvent(event, wrongChallenge, relayUrls, maxAuthAge)
+      )
+
+      expect(result.valid).toBe(false)
+      expect(result.error).toContain("challenge mismatch")
+    })
+
+    it("should reject relay URL mismatch", async () => {
+      const challenge = generateChallenge()
+      const event = await createAuthEvent(challenge, "wss://other-relay.com")
+
+      const result = await runWithServices(
+        verifyAuthEvent(event, challenge, relayUrls, maxAuthAge)
+      )
+
+      expect(result.valid).toBe(false)
+      expect(result.error).toContain("relay URL mismatch")
+    })
+
+    it("should reject event too old", async () => {
+      const challenge = generateChallenge()
+      const oldTimestamp = Math.floor(Date.now() / 1000) - 1200 // 20 minutes ago
+      const event = await createAuthEvent(challenge, "wss://relay.example.com", {
+        createdAt: oldTimestamp,
+      })
+
+      const result = await runWithServices(
+        verifyAuthEvent(event, challenge, relayUrls, maxAuthAge)
+      )
+
+      expect(result.valid).toBe(false)
+      expect(result.error).toContain("too old")
+    })
+
+    it("should accept matching relay domain regardless of path", async () => {
+      const challenge = generateChallenge()
+      const event = await createAuthEvent(challenge, "wss://relay.example.com/nostr")
+
+      const result = await runWithServices(
+        verifyAuthEvent(event, challenge, relayUrls, maxAuthAge)
+      )
+
+      // Domain matches, so it should be valid
+      expect(result.valid).toBe(true)
+    })
+
+    it("should support multiple relay URLs", async () => {
+      const multiRelayUrls = [
+        "wss://relay.example.com",
+        "wss://backup.example.com",
+      ]
+      const challenge = generateChallenge()
+      const event = await createAuthEvent(challenge, "wss://backup.example.com")
+
+      const result = await runWithServices(
+        verifyAuthEvent(event, challenge, multiRelayUrls, maxAuthAge)
+      )
+
+      expect(result.valid).toBe(true)
+    })
+  })
+
+  describe("createNip42Module", () => {
+    it("should create module with correct NIP number", () => {
+      const module = createNip42Module({ relayUrls: ["wss://test.com"] })
+      expect(module.nips).toContain(42)
+      expect(module.id).toBe("nip-42")
+    })
+
+    it("should include AUTH_EVENT_KIND in handled kinds", () => {
+      const module = createNip42Module({ relayUrls: ["wss://test.com"] })
+      expect(module.kinds).toContain(AUTH_EVENT_KIND)
+    })
+
+    it("should set auth_required limitation when configured", () => {
+      const module = createNip42Module({
+        relayUrls: ["wss://test.com"],
+        authRequired: true,
+      })
+      expect(module.limitations?.auth_required).toBe(true)
+    })
+
+    it("should have policy that shadows AUTH events", async () => {
+      const module = createNip42Module({ relayUrls: ["wss://test.com"] })
+      expect(module.policies.length).toBeGreaterThan(0)
+
+      // The policy should shadow (not store) AUTH events
+      const challenge = generateChallenge()
+      const event = await createAuthEvent(challenge, "wss://test.com")
+
+      const policy = module.policies[0]!
+      // The rejectAuthKind policy doesn't require any services (Policy<never>)
+      const result = await Effect.runPromise(
+        policy({
+          event,
+          connectionId: "test",
+          remoteAddress: undefined,
+        }) as Effect.Effect<PolicyDecision>
+      )
+
+      expect(result._tag).toBe("Shadow")
+    })
+
+    it("should accept non-AUTH events", async () => {
+      const module = createNip42Module({ relayUrls: ["wss://test.com"] })
+      const policy = module.policies[0]!
+
+      // Create a regular event (not AUTH)
+      const layer = Layer.provide(EventServiceLive, CryptoServiceLive)
+      const event = await Effect.runPromise(
+        Effect.provide(
+          Effect.gen(function* () {
+            const eventService = yield* EventService
+            return yield* eventService.createEvent(
+              {
+                kind: 1 as EventKind,
+                tags: [],
+                content: "hello",
+              },
+              testPrivateKey
+            )
+          }),
+          layer
+        )
+      )
+
+      // The rejectAuthKind policy doesn't require any services (Policy<never>)
+      const result = await Effect.runPromise(
+        policy({
+          event,
+          connectionId: "test",
+          remoteAddress: undefined,
+        }) as Effect.Effect<PolicyDecision>
+      )
+
+      expect(result._tag).toBe("Accept")
+    })
+  })
+})

--- a/src/relay/core/nip/modules/Nip42Module.ts
+++ b/src/relay/core/nip/modules/Nip42Module.ts
@@ -1,0 +1,192 @@
+/**
+ * NIP-42 Module
+ *
+ * Authentication of clients to relays.
+ * Handles AUTH message flow and event verification.
+ */
+import { Effect } from "effect"
+import { type NipModule, createModule } from "../NipModule.js"
+import { type Policy, Shadow } from "../../policy/Policy.js"
+import type { NostrEvent, PublicKey } from "../../../../core/Schema.js"
+import { AUTH_EVENT_KIND } from "../../../../core/Schema.js"
+import { EventService } from "../../../../services/EventService.js"
+import type { CryptoError, InvalidPublicKey } from "../../../../core/Errors.js"
+
+// =============================================================================
+// Configuration
+// =============================================================================
+
+export interface Nip42Config {
+  /**
+   * Relay URL(s) to match against auth event's relay tag
+   * Supports multiple URLs for relays with different endpoints
+   */
+  readonly relayUrls: readonly string[]
+  /**
+   * Maximum age of auth events in seconds (default: 600 = 10 minutes)
+   */
+  readonly maxAuthAge?: number
+  /**
+   * Whether auth is required for all connections (default: false)
+   * If true, unauthenticated clients will receive auth-required errors
+   */
+  readonly authRequired?: boolean
+}
+
+interface InternalConfig {
+  relayUrls: readonly string[]
+  maxAuthAge: number
+  authRequired: boolean
+}
+
+const DEFAULT_CONFIG: Omit<InternalConfig, "relayUrls"> = {
+  maxAuthAge: 600, // 10 minutes
+  authRequired: false,
+}
+
+// =============================================================================
+// Auth Event Verification
+// =============================================================================
+
+export interface AuthVerificationResult {
+  readonly valid: boolean
+  readonly pubkey?: PublicKey
+  readonly error?: string
+}
+
+/**
+ * Verify a NIP-42 auth event
+ * Checks: kind, created_at, challenge tag, relay tag, signature
+ */
+export const verifyAuthEvent = (
+  event: NostrEvent,
+  expectedChallenge: string,
+  relayUrls: readonly string[],
+  maxAuthAge: number
+): Effect.Effect<AuthVerificationResult, CryptoError | InvalidPublicKey, EventService> =>
+  Effect.gen(function* () {
+    // Check kind
+    if (event.kind !== AUTH_EVENT_KIND) {
+      return { valid: false, error: `invalid: expected kind ${AUTH_EVENT_KIND}, got ${event.kind}` }
+    }
+
+    // Check created_at is within maxAuthAge
+    const now = Math.floor(Date.now() / 1000)
+    const age = Math.abs(now - event.created_at)
+    if (age > maxAuthAge) {
+      return { valid: false, error: `invalid: auth event too old (${age}s > ${maxAuthAge}s)` }
+    }
+
+    // Find and verify challenge tag
+    const challengeTag = event.tags.find((tag) => tag[0] === "challenge")
+    if (!challengeTag || challengeTag[1] !== expectedChallenge) {
+      return { valid: false, error: "invalid: challenge mismatch" }
+    }
+
+    // Find and verify relay tag (URL normalization: just check domain match)
+    const relayTag = event.tags.find((tag) => tag[0] === "relay")
+    if (!relayTag || !relayTag[1]) {
+      return { valid: false, error: "invalid: missing relay tag" }
+    }
+
+    const eventRelayUrl = normalizeRelayUrl(relayTag[1])
+    const normalizedRelayUrls = relayUrls.map(normalizeRelayUrl)
+    if (!normalizedRelayUrls.some((url) => urlsMatch(url, eventRelayUrl))) {
+      return { valid: false, error: "invalid: relay URL mismatch" }
+    }
+
+    // Verify signature
+    const eventService = yield* EventService
+    const isValid = yield* eventService.verifyEvent(event)
+    if (!isValid) {
+      return { valid: false, error: "invalid: signature verification failed" }
+    }
+
+    return { valid: true, pubkey: event.pubkey }
+  })
+
+/**
+ * Normalize relay URL for comparison
+ * Removes trailing slashes, converts to lowercase
+ */
+const normalizeRelayUrl = (url: string): string => {
+  try {
+    const parsed = new URL(url)
+    // Remove trailing slash and convert to lowercase
+    return `${parsed.protocol}//${parsed.host}${parsed.pathname.replace(/\/$/, "")}`.toLowerCase()
+  } catch {
+    // If URL parsing fails, just lowercase and remove trailing slash
+    return url.toLowerCase().replace(/\/$/, "")
+  }
+}
+
+/**
+ * Check if two URLs match (domain match is sufficient per NIP-42)
+ */
+const urlsMatch = (url1: string, url2: string): boolean => {
+  try {
+    const parsed1 = new URL(url1)
+    const parsed2 = new URL(url2)
+    // NIP-42: "For most cases just checking if the domain name is correct should be enough"
+    return parsed1.host.toLowerCase() === parsed2.host.toLowerCase()
+  } catch {
+    // Fallback to exact match if URL parsing fails
+    return url1 === url2
+  }
+}
+
+// =============================================================================
+// Policy: Reject AUTH events from being stored
+// =============================================================================
+
+/**
+ * Policy that shadows kind 22242 events (AUTH events should not be stored)
+ * NIP-42: "Relays MUST exclude kind: 22242 events from being broadcasted to any client"
+ */
+const rejectAuthKind: Policy<never> = (ctx) =>
+  Effect.succeed(
+    ctx.event.kind === AUTH_EVENT_KIND ? Shadow : { _tag: "Accept" }
+  )
+
+// =============================================================================
+// Challenge Generation
+// =============================================================================
+
+/**
+ * Generate a random challenge string
+ * Uses crypto.randomUUID() for simplicity
+ */
+export const generateChallenge = (): string => crypto.randomUUID()
+
+// =============================================================================
+// Module
+// =============================================================================
+
+/**
+ * Create NIP-42 module with configuration
+ */
+export const createNip42Module = (config: Nip42Config): NipModule => {
+  const cfg: InternalConfig = {
+    ...DEFAULT_CONFIG,
+    ...config,
+  }
+
+  return createModule({
+    id: "nip-42",
+    nips: [42],
+    description: "Authentication of clients to relays",
+    kinds: [AUTH_EVENT_KIND],
+    policies: [rejectAuthKind],
+    relayInfo: {
+      ...(cfg.authRequired && { limitation: { auth_required: true } }),
+    },
+    limitations: {
+      ...(cfg.authRequired && { auth_required: true }),
+    },
+  })
+}
+
+/**
+ * NIP-42 module requires configuration (relay URLs), so no default instance
+ * Use createNip42Module(config) to create one
+ */

--- a/src/relay/core/nip/modules/index.ts
+++ b/src/relay/core/nip/modules/index.ts
@@ -8,6 +8,13 @@
 export { Nip01Module, createNip01Module, type Nip01Config } from "./Nip01Module.js"
 export { Nip11Module, createNip11Module, type Nip11Config } from "./Nip11Module.js"
 export { Nip16Module } from "./Nip16Module.js"
+export {
+  createNip42Module,
+  verifyAuthEvent,
+  generateChallenge,
+  type Nip42Config,
+  type AuthVerificationResult,
+} from "./Nip42Module.js"
 
 // =============================================================================
 // Default Module Set


### PR DESCRIPTION
## Summary
- Implements NIP-42 authentication for relay-to-client auth flows
- Add AUTH message types (ClientAuthMessage, RelayAuthMessage) to Schema
- Create Nip42Module with auth event verification (kind 22242) 
- Create AuthService integrating with ConnectionManager
- Add AUTH message handling to MessageHandler
- Add policy to shadow AUTH events (don't store/broadcast)
- 26 new tests for auth flow and nostr-tools parity

Closes #12

## Test plan
- [x] Run `bun run verify` - 320 tests passing
- [x] Auth event format matches nostr-tools spec
- [x] Challenge generation and verification work
- [x] ConnectionManager integration working

🤖 Generated with [Claude Code](https://claude.com/claude-code)