### PR TITLE
Add NIP-28 Public Chat support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,6 +175,43 @@ After completing each issue:
 3. Move any completed issues from "Open Issues" to "Completed"
 4. Commit the BUILDOUT.md update to main
 
+## NIP Module System
+
+The relay uses a pluggable NIP module system for adding protocol support. Key files:
+
+- `src/relay/core/nip/NipModule.ts` - Interface definition for NIP modules
+- `src/relay/core/nip/NipRegistry.ts` - Service for managing/combining modules
+- `src/relay/core/nip/modules/` - Built-in module implementations
+
+### Creating a NIP Module
+
+```typescript
+import { createModule } from "../NipModule.js"
+
+export const MyNipModule = createModule({
+  id: "nip-XX",           // Unique identifier
+  nips: [XX],             // NIP numbers implemented
+  description: "...",     // Human-readable description
+  kinds: [N, M, ...],     // Event kinds handled (empty = all kinds)
+  policies: [],           // Validation policies (see Policy.ts)
+  preStoreHook: (event) => Effect.succeed({ action: "store", event }),  // Optional
+  postStoreHook: (event) => Effect.void,  // Optional
+  limitations: {},        // NIP-11 relay limitations
+})
+```
+
+### Key Concepts
+
+- **policies**: Validation rules that Accept/Reject/Shadow events
+- **preStoreHook**: Called before storage, can modify/reject/replace events
+- **postStoreHook**: Called after storage for side effects
+- **limitations**: Contributes to NIP-11 relay info document
+
+### Reference PRs
+
+- Issue #5 / PR #41 - Original NIP module system implementation
+- See existing modules (Nip01Module, Nip16Module, Nip28Module, Nip42Module) for patterns
+
 ## Nostr NIPs Reference
 
 **Local NIPs Repository:** The NIPs specification repo is cloned locally at `~/code/nips`. When implementing a NIP, read the spec from there instead of fetching from GitHub:

--- a/docs/BUILDOUT.md
+++ b/docs/BUILDOUT.md
@@ -32,7 +32,7 @@ src/
 - **Services**: CryptoService, EventService, Nip44Service (NIP-44 versioned encryption)
 - **Relay**: EventStore, SubscriptionManager, MessageHandler, RelayServer, PolicyPipeline, NIP-16/33 Replaceable Events, NIP-11 Relay Info, NIP Module System, Timestamp Limits, ConnectionManager, NIP-42 Authentication (AuthService)
 - **Relay Backends**: Bun (SQLite), Cloudflare Durable Objects (DO SQLite)
-- **Client**: RelayService (WebSocket connection management), FollowListService (NIP-02), RelayListService (NIP-65), HandlerService (NIP-89), DVMService (NIP-90)
+- **Client**: RelayService (WebSocket connection management), FollowListService (NIP-02), RelayListService (NIP-65), HandlerService (NIP-89), DVMService (NIP-90), ChatService (NIP-28)
 
 ### Open Issues
 
@@ -209,6 +209,7 @@ src/client/
 | NIP-44 | `nip44.test.ts` + vectors | `src/services/Nip44Service.test.ts` | ✅ Done |
 | NIP-04 | `nip04.test.ts` | - | ⬜ Not planned |
 | NIP-05 | `nip05.test.ts` | `src/client/Nip05Service.test.ts` | ⬜ Not started |
+| NIP-28 | `nip28.test.ts` | `src/client/ChatService.test.ts` | ✅ Done |
 
 ### Adding a New NIP
 

--- a/src/client/ChatService.test.ts
+++ b/src/client/ChatService.test.ts
@@ -1,0 +1,572 @@
+/**
+ * Tests for ChatService (NIP-28)
+ *
+ * Test parity with nostr-tools nip28.test.ts
+ */
+import { test, expect, describe, beforeAll, afterAll } from "bun:test"
+import { Effect, Layer } from "effect"
+import { ChatService, ChatServiceLive, type ChannelMetadata } from "./ChatService.js"
+import { RelayService, makeRelayService } from "./RelayService.js"
+import { startTestRelay, type RelayHandle } from "../relay/index.js"
+import { CryptoService, CryptoServiceLive } from "../services/CryptoService.js"
+import { EventServiceLive } from "../services/EventService.js"
+import type { EventId } from "../core/Schema.js"
+
+// NIP-28 kinds as plain numbers for comparison
+const CHANNEL_CREATE = 40
+const CHANNEL_METADATA = 41
+const CHANNEL_MESSAGE = 42
+const CHANNEL_HIDE_MESSAGE = 43
+const CHANNEL_MUTE_USER = 44
+
+describe("ChatService (NIP-28)", () => {
+  let relay: RelayHandle
+  let port: number
+
+  beforeAll(async () => {
+    port = 13000 + Math.floor(Math.random() * 10000)
+    relay = await startTestRelay(port)
+  })
+
+  afterAll(async () => {
+    await Effect.runPromise(relay.stop())
+  })
+
+  const makeTestLayers = () => {
+    const RelayLayer = makeRelayService({
+      url: `ws://localhost:${port}`,
+      reconnect: false,
+    })
+
+    const ServiceLayer = Layer.merge(
+      CryptoServiceLive,
+      EventServiceLive.pipe(Layer.provide(CryptoServiceLive))
+    )
+
+    return Layer.merge(
+      RelayLayer,
+      Layer.merge(
+        ServiceLayer,
+        ChatServiceLive.pipe(
+          Layer.provide(RelayLayer),
+          Layer.provide(ServiceLayer)
+        )
+      )
+    )
+  }
+
+  describe("createChannel (nostr-tools parity)", () => {
+    test("creates channel with correct kind and metadata", async () => {
+      const program = Effect.gen(function* () {
+        const relayService = yield* RelayService
+        const chatService = yield* ChatService
+        const crypto = yield* CryptoService
+
+        yield* relayService.connect()
+
+        const privateKey = yield* crypto.generatePrivateKey()
+        const pubkey = yield* crypto.getPublicKey(privateKey)
+
+        const metadata: ChannelMetadata = {
+          name: "Test Channel",
+          about: "This is a test channel",
+          picture: "https://example.com/picture.jpg",
+        }
+
+        const event = yield* chatService.createChannel(
+          { content: metadata },
+          privateKey
+        )
+
+        // Matches nostr-tools nip28.test.ts assertions
+        expect(event.kind as number).toBe(CHANNEL_CREATE)
+        expect(event.content).toBe(JSON.stringify(metadata))
+        expect(event.pubkey).toBe(pubkey)
+        expect(typeof event.id).toBe("string")
+        expect(typeof event.sig).toBe("string")
+
+        yield* relayService.disconnect()
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+
+    test("creates channel with string content", async () => {
+      const program = Effect.gen(function* () {
+        const relayService = yield* RelayService
+        const chatService = yield* ChatService
+        const crypto = yield* CryptoService
+
+        yield* relayService.connect()
+
+        const privateKey = yield* crypto.generatePrivateKey()
+
+        const content = '{"name": "String Channel", "about": "From string", "picture": ""}'
+
+        const event = yield* chatService.createChannel(
+          { content },
+          privateKey
+        )
+
+        expect(event.kind as number).toBe(CHANNEL_CREATE)
+        expect(event.content).toBe(content)
+
+        yield* relayService.disconnect()
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+  })
+
+  describe("updateChannelMetadata (nostr-tools parity)", () => {
+    test("creates metadata event with e tag reference", async () => {
+      const program = Effect.gen(function* () {
+        const relayService = yield* RelayService
+        const chatService = yield* ChatService
+        const crypto = yield* CryptoService
+
+        yield* relayService.connect()
+
+        const privateKey = yield* crypto.generatePrivateKey()
+        const pubkey = yield* crypto.getPublicKey(privateKey)
+
+        const channelCreateEventId = "channel_creation_event_id"
+        const metadata: ChannelMetadata = {
+          name: "Updated Channel",
+          about: "Updated description",
+          picture: "https://example.com/new.jpg",
+        }
+
+        const event = yield* chatService.updateChannelMetadata(
+          {
+            channelCreateEventId,
+            content: metadata,
+          },
+          privateKey
+        )
+
+        // Matches nostr-tools nip28.test.ts assertions
+        expect(event.kind as number).toBe(CHANNEL_METADATA)
+        // Check that the e tag exists
+        const eTag = event.tags.find(t => t[0] === "e" && t[1] === channelCreateEventId)
+        expect(eTag).toBeDefined()
+        expect(event.content).toBe(JSON.stringify(metadata))
+        expect(event.pubkey).toBe(pubkey)
+        expect(typeof event.id).toBe("string")
+        expect(typeof event.sig).toBe("string")
+
+        yield* relayService.disconnect()
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+
+    test("includes relay hint and root marker", async () => {
+      const program = Effect.gen(function* () {
+        const relayService = yield* RelayService
+        const chatService = yield* ChatService
+        const crypto = yield* CryptoService
+
+        yield* relayService.connect()
+
+        const privateKey = yield* crypto.generatePrivateKey()
+
+        const event = yield* chatService.updateChannelMetadata(
+          {
+            channelCreateEventId: "channel_id",
+            content: { name: "Test", about: "", picture: "" },
+            relayUrl: "wss://relay.example.com",
+          },
+          privateKey
+        )
+
+        const firstTag = event.tags[0]!
+        expect(firstTag[0]).toBe("e")
+        expect(firstTag[1]).toBe("channel_id")
+        expect(firstTag[2]).toBe("wss://relay.example.com")
+        expect(firstTag[3]).toBe("root")
+
+        yield* relayService.disconnect()
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+
+    test("includes category tags", async () => {
+      const program = Effect.gen(function* () {
+        const relayService = yield* RelayService
+        const chatService = yield* ChatService
+        const crypto = yield* CryptoService
+
+        yield* relayService.connect()
+
+        const privateKey = yield* crypto.generatePrivateKey()
+
+        const event = yield* chatService.updateChannelMetadata(
+          {
+            channelCreateEventId: "channel_id",
+            content: { name: "Test", about: "", picture: "" },
+            categories: ["tech", "programming"],
+          },
+          privateKey
+        )
+
+        const techTag = event.tags.find(t => t[0] === "t" && t[1] === "tech")
+        const progTag = event.tags.find(t => t[0] === "t" && t[1] === "programming")
+        expect(techTag).toBeDefined()
+        expect(progTag).toBeDefined()
+
+        yield* relayService.disconnect()
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+  })
+
+  describe("sendMessage (nostr-tools parity)", () => {
+    test("creates message event with root tag", async () => {
+      const program = Effect.gen(function* () {
+        const relayService = yield* RelayService
+        const chatService = yield* ChatService
+        const crypto = yield* CryptoService
+
+        yield* relayService.connect()
+
+        const privateKey = yield* crypto.generatePrivateKey()
+        const pubkey = yield* crypto.getPublicKey(privateKey)
+
+        const channelCreateEventId = "channel_creation_event_id"
+        const relayUrl = "wss://relay.example.com"
+        const content = "Hello, world!"
+
+        const event = yield* chatService.sendMessage(
+          {
+            channelCreateEventId,
+            relayUrl,
+            content,
+          },
+          privateKey
+        )
+
+        // Matches nostr-tools nip28.test.ts assertions
+        expect(event.kind as number).toBe(CHANNEL_MESSAGE)
+        const firstTag = event.tags[0]!
+        expect(firstTag[0]).toBe("e")
+        expect(firstTag[1]).toBe(channelCreateEventId)
+        expect(firstTag[2]).toBe(relayUrl)
+        expect(firstTag[3]).toBe("root")
+        expect(event.content).toBe(content)
+        expect(event.pubkey).toBe(pubkey)
+        expect(typeof event.id).toBe("string")
+        expect(typeof event.sig).toBe("string")
+
+        yield* relayService.disconnect()
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+
+    test("creates reply event with root and reply tags", async () => {
+      const program = Effect.gen(function* () {
+        const relayService = yield* RelayService
+        const chatService = yield* ChatService
+        const crypto = yield* CryptoService
+
+        yield* relayService.connect()
+
+        const privateKey = yield* crypto.generatePrivateKey()
+        const pubkey = yield* crypto.getPublicKey(privateKey)
+
+        const channelCreateEventId = "channel_creation_event_id"
+        const replyToEventId = "channel_message_event_id"
+        const relayUrl = "wss://relay.example.com"
+        const content = "This is a reply!"
+
+        const event = yield* chatService.sendMessage(
+          {
+            channelCreateEventId,
+            relayUrl,
+            content,
+            replyToEventId,
+          },
+          privateKey
+        )
+
+        // Matches nostr-tools nip28.test.ts assertions for reply messages
+        expect(event.kind as number).toBe(CHANNEL_MESSAGE)
+
+        const rootTag = event.tags.find(tag => tag[0] === "e" && tag[1] === channelCreateEventId)
+        expect(rootTag).toBeDefined()
+        expect(rootTag![2]).toBe(relayUrl)
+        expect(rootTag![3]).toBe("root")
+
+        const replyTag = event.tags.find(tag => tag[0] === "e" && tag[1] === replyToEventId)
+        expect(replyTag).toBeDefined()
+        expect(replyTag![2]).toBe(relayUrl)
+        expect(replyTag![3]).toBe("reply")
+
+        expect(event.content).toBe(content)
+        expect(event.pubkey).toBe(pubkey)
+
+        yield* relayService.disconnect()
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+  })
+
+  describe("hideMessage (nostr-tools parity)", () => {
+    test("creates hide event with e tag and reason", async () => {
+      const program = Effect.gen(function* () {
+        const relayService = yield* RelayService
+        const chatService = yield* ChatService
+        const crypto = yield* CryptoService
+
+        yield* relayService.connect()
+
+        const privateKey = yield* crypto.generatePrivateKey()
+        const pubkey = yield* crypto.getPublicKey(privateKey)
+
+        const channelMessageEventId = "channel_message_event_id"
+        const reason = { reason: "Inappropriate content" }
+
+        const event = yield* chatService.hideMessage(
+          {
+            channelMessageEventId,
+            content: reason,
+          },
+          privateKey
+        )
+
+        // Matches nostr-tools nip28.test.ts assertions
+        expect(event.kind as number).toBe(CHANNEL_HIDE_MESSAGE)
+        const eTag = event.tags.find(t => t[0] === "e" && t[1] === channelMessageEventId)
+        expect(eTag).toBeDefined()
+        expect(event.content).toBe(JSON.stringify(reason))
+        expect(event.pubkey).toBe(pubkey)
+        expect(typeof event.id).toBe("string")
+        expect(typeof event.sig).toBe("string")
+
+        yield* relayService.disconnect()
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+
+    test("accepts string content", async () => {
+      const program = Effect.gen(function* () {
+        const relayService = yield* RelayService
+        const chatService = yield* ChatService
+        const crypto = yield* CryptoService
+
+        yield* relayService.connect()
+
+        const privateKey = yield* crypto.generatePrivateKey()
+
+        const event = yield* chatService.hideMessage(
+          {
+            channelMessageEventId: "msg_id",
+            content: '{"reason": "Spam"}',
+          },
+          privateKey
+        )
+
+        expect(event.content).toBe('{"reason": "Spam"}')
+
+        yield* relayService.disconnect()
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+  })
+
+  describe("muteUser (nostr-tools parity)", () => {
+    test("creates mute event with p tag and reason", async () => {
+      const program = Effect.gen(function* () {
+        const relayService = yield* RelayService
+        const chatService = yield* ChatService
+        const crypto = yield* CryptoService
+
+        yield* relayService.connect()
+
+        const privateKey = yield* crypto.generatePrivateKey()
+        const pubkey = yield* crypto.getPublicKey(privateKey)
+
+        const pubkeyToMute = "pubkey_to_mute"
+        const reason = { reason: "Spamming" }
+
+        const event = yield* chatService.muteUser(
+          {
+            pubkeyToMute,
+            content: reason,
+          },
+          privateKey
+        )
+
+        // Matches nostr-tools nip28.test.ts assertions
+        expect(event.kind as number).toBe(CHANNEL_MUTE_USER)
+        const pTag = event.tags.find(t => t[0] === "p" && t[1] === pubkeyToMute)
+        expect(pTag).toBeDefined()
+        expect(event.content).toBe(JSON.stringify(reason))
+        expect(event.pubkey).toBe(pubkey)
+        expect(typeof event.id).toBe("string")
+        expect(typeof event.sig).toBe("string")
+
+        yield* relayService.disconnect()
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+  })
+
+  describe("getChannel", () => {
+    test("retrieves channel by creation event id", async () => {
+      const program = Effect.gen(function* () {
+        const relayService = yield* RelayService
+        const chatService = yield* ChatService
+        const crypto = yield* CryptoService
+
+        yield* relayService.connect()
+
+        const privateKey = yield* crypto.generatePrivateKey()
+
+        const metadata: ChannelMetadata = {
+          name: "Queryable Channel",
+          about: "Can be queried",
+          picture: "https://example.com/pic.jpg",
+        }
+
+        // Create channel
+        const createEvent = yield* chatService.createChannel(
+          { content: metadata },
+          privateKey
+        )
+
+        yield* Effect.sleep(500)
+
+        // Query channel
+        const result = yield* chatService.getChannel(createEvent.id)
+
+        expect(result.createEvent).toBeDefined()
+        expect(result.createEvent?.id).toBe(createEvent.id)
+        expect(result.metadata?.name).toBe(metadata.name)
+        expect(result.metadata?.about).toBe(metadata.about)
+
+        yield* relayService.disconnect()
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+
+    test("returns empty result for unknown channel", async () => {
+      const program = Effect.gen(function* () {
+        const relayService = yield* RelayService
+        const chatService = yield* ChatService
+
+        yield* relayService.connect()
+
+        // Use a fake event ID
+        const fakeChannelId = "0000000000000000000000000000000000000000000000000000000000000000" as EventId
+
+        const result = yield* chatService.getChannel(fakeChannelId)
+
+        expect(result.createEvent).toBeUndefined()
+        expect(result.metadata).toBeUndefined()
+
+        yield* relayService.disconnect()
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+  })
+
+  describe("getMessages", () => {
+    test("retrieves messages from channel", async () => {
+      const program = Effect.gen(function* () {
+        const relayService = yield* RelayService
+        const chatService = yield* ChatService
+        const crypto = yield* CryptoService
+
+        yield* relayService.connect()
+
+        const privateKey = yield* crypto.generatePrivateKey()
+
+        // Create channel
+        const createEvent = yield* chatService.createChannel(
+          {
+            content: {
+              name: "Message Test Channel",
+              about: "Testing messages",
+              picture: "",
+            },
+          },
+          privateKey
+        )
+
+        yield* Effect.sleep(300)
+
+        // Send messages
+        yield* chatService.sendMessage(
+          {
+            channelCreateEventId: createEvent.id,
+            relayUrl: `ws://localhost:${port}`,
+            content: "First message",
+          },
+          privateKey
+        )
+
+        yield* chatService.sendMessage(
+          {
+            channelCreateEventId: createEvent.id,
+            relayUrl: `ws://localhost:${port}`,
+            content: "Second message",
+          },
+          privateKey
+        )
+
+        yield* Effect.sleep(500)
+
+        // Get messages
+        const messages = yield* chatService.getMessages(createEvent.id)
+
+        expect(messages.length).toBeGreaterThanOrEqual(2)
+        expect(messages.some(m => m.content === "First message")).toBe(true)
+        expect(messages.some(m => m.content === "Second message")).toBe(true)
+
+        yield* relayService.disconnect()
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+  })
+})
+
+describe("Nip28Module", () => {
+  test("has correct module configuration", async () => {
+    const { Nip28Module } = await import("../relay/core/nip/modules/Nip28Module.js")
+
+    expect(Nip28Module.id).toBe("nip-28")
+    expect(Nip28Module.nips).toContain(28)
+    expect(Nip28Module.kinds).toContain(CHANNEL_CREATE)
+    expect(Nip28Module.kinds).toContain(CHANNEL_METADATA)
+    expect(Nip28Module.kinds).toContain(CHANNEL_MESSAGE)
+    expect(Nip28Module.kinds).toContain(CHANNEL_HIDE_MESSAGE)
+    expect(Nip28Module.kinds).toContain(CHANNEL_MUTE_USER)
+  })
+
+  test("integrates with NipRegistry", async () => {
+    const { Nip28Module } = await import("../relay/core/nip/modules/Nip28Module.js")
+    const { NipRegistryLive, NipRegistry } = await import("../relay/core/nip/index.js")
+    const { Effect } = await import("effect")
+
+    const program = Effect.gen(function* () {
+      const registry = yield* NipRegistry
+      expect(registry.supportedNips).toContain(28)
+      expect(registry.hasModule("nip-28")).toBe(true)
+    })
+
+    await Effect.runPromise(
+      program.pipe(Effect.provide(NipRegistryLive([Nip28Module])))
+    )
+  })
+})

--- a/src/client/ChatService.ts
+++ b/src/client/ChatService.ts
@@ -1,0 +1,577 @@
+/**
+ * ChatService
+ *
+ * NIP-28 public chat service.
+ * Manages public chat channels, messages, and client-side moderation.
+ *
+ * @see https://github.com/nostr-protocol/nips/blob/master/28.md
+ */
+import { Context, Effect, Layer, Option, Stream } from "effect"
+import { Schema } from "@effect/schema"
+import { RelayService } from "./RelayService.js"
+import { EventService } from "../services/EventService.js"
+import { RelayError } from "../core/Errors.js"
+import {
+  type NostrEvent,
+  type PublicKey,
+  type PrivateKey,
+  type EventId,
+  EventKind,
+  Filter,
+  Tag,
+  CHANNEL_CREATE_KIND,
+  CHANNEL_METADATA_KIND,
+  CHANNEL_MESSAGE_KIND,
+  CHANNEL_HIDE_MESSAGE_KIND,
+  CHANNEL_MUTE_USER_KIND,
+} from "../core/Schema.js"
+
+// =============================================================================
+// Types
+// =============================================================================
+
+const decodeKind = Schema.decodeSync(EventKind)
+const decodeFilter = Schema.decodeSync(Filter)
+const decodeTag = Schema.decodeSync(Tag)
+
+/** Channel metadata as defined in NIP-28 */
+export interface ChannelMetadata {
+  /** Channel name */
+  readonly name: string
+  /** Channel description */
+  readonly about: string
+  /** URL of channel picture */
+  readonly picture: string
+  /** Recommended relays for channel events */
+  readonly relays?: readonly string[]
+}
+
+/** Parameters for creating a channel */
+export interface CreateChannelParams {
+  /** Channel metadata (or JSON string) */
+  readonly content: ChannelMetadata | string
+  /** Optional additional tags */
+  readonly tags?: readonly string[][]
+}
+
+/** Parameters for updating channel metadata */
+export interface UpdateChannelMetadataParams {
+  /** Event ID of the channel creation event (kind 40) */
+  readonly channelCreateEventId: string
+  /** Channel metadata (or JSON string) */
+  readonly content: ChannelMetadata | string
+  /** Optional relay URL hint for the channel */
+  readonly relayUrl?: string
+  /** Optional category tags */
+  readonly categories?: readonly string[]
+  /** Optional additional tags */
+  readonly tags?: readonly string[][]
+}
+
+/** Parameters for sending a channel message */
+export interface SendChannelMessageParams {
+  /** Event ID of the channel creation event (kind 40) */
+  readonly channelCreateEventId: string
+  /** Relay URL for the channel */
+  readonly relayUrl: string
+  /** Message content */
+  readonly content: string
+  /** Optional: Reply to another message event ID */
+  readonly replyToEventId?: string
+  /** Optional: Pubkeys to mention in the reply */
+  readonly mentionPubkeys?: readonly PublicKey[]
+  /** Optional additional tags */
+  readonly tags?: readonly string[][]
+}
+
+/** Parameters for hiding a message */
+export interface HideMessageParams {
+  /** Event ID of the channel message to hide (kind 42) */
+  readonly channelMessageEventId: string
+  /** Reason for hiding (or JSON string) */
+  readonly content: { reason: string } | string
+  /** Optional additional tags */
+  readonly tags?: readonly string[][]
+}
+
+/** Parameters for muting a user */
+export interface MuteUserParams {
+  /** Public key of the user to mute */
+  readonly pubkeyToMute: string
+  /** Reason for muting (or JSON string) */
+  readonly content: { reason: string } | string
+  /** Optional additional tags */
+  readonly tags?: readonly string[][]
+}
+
+/** Result of a channel query */
+export interface ChannelResult {
+  /** The channel metadata */
+  readonly metadata?: ChannelMetadata
+  /** The original creation event */
+  readonly createEvent?: NostrEvent
+  /** The latest metadata event (if any) */
+  readonly metadataEvent?: NostrEvent
+}
+
+/** A channel message */
+export interface ChannelMessage {
+  /** The message event */
+  readonly event: NostrEvent
+  /** The channel this message belongs to */
+  readonly channelId: EventId
+  /** The message content */
+  readonly content: string
+  /** Reply-to event ID (if a reply) */
+  readonly replyTo?: EventId
+}
+
+// =============================================================================
+// Service Interface
+// =============================================================================
+
+export interface ChatService {
+  readonly _tag: "ChatService"
+
+  /**
+   * Create a new public chat channel (kind 40)
+   */
+  createChannel(
+    params: CreateChannelParams,
+    privateKey: PrivateKey
+  ): Effect.Effect<NostrEvent, RelayError>
+
+  /**
+   * Update channel metadata (kind 41)
+   * Only the channel creator should update metadata
+   */
+  updateChannelMetadata(
+    params: UpdateChannelMetadataParams,
+    privateKey: PrivateKey
+  ): Effect.Effect<NostrEvent, RelayError>
+
+  /**
+   * Send a message to a channel (kind 42)
+   */
+  sendMessage(
+    params: SendChannelMessageParams,
+    privateKey: PrivateKey
+  ): Effect.Effect<NostrEvent, RelayError>
+
+  /**
+   * Hide a message - client-side moderation (kind 43)
+   */
+  hideMessage(
+    params: HideMessageParams,
+    privateKey: PrivateKey
+  ): Effect.Effect<NostrEvent, RelayError>
+
+  /**
+   * Mute a user - client-side moderation (kind 44)
+   */
+  muteUser(
+    params: MuteUserParams,
+    privateKey: PrivateKey
+  ): Effect.Effect<NostrEvent, RelayError>
+
+  /**
+   * Get channel information by creation event ID
+   */
+  getChannel(channelId: EventId): Effect.Effect<ChannelResult, RelayError>
+
+  /**
+   * Get messages from a channel
+   */
+  getMessages(
+    channelId: EventId,
+    limit?: number
+  ): Effect.Effect<readonly ChannelMessage[], RelayError>
+}
+
+// =============================================================================
+// Service Tag
+// =============================================================================
+
+export const ChatService = Context.GenericTag<ChatService>("ChatService")
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/**
+ * Serialize content to JSON string if needed
+ */
+const serializeContent = (content: unknown): string => {
+  if (typeof content === "string") {
+    return content
+  }
+  return JSON.stringify(content)
+}
+
+/**
+ * Parse channel metadata from event content
+ */
+const parseChannelMetadata = (content: string): ChannelMetadata | undefined => {
+  try {
+    const parsed = JSON.parse(content)
+    if (typeof parsed.name === "string" && typeof parsed.about === "string" && typeof parsed.picture === "string") {
+      return parsed as ChannelMetadata
+    }
+    return undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Get the root channel ID from message event tags
+ */
+const getChannelIdFromMessage = (event: NostrEvent): EventId | undefined => {
+  const rootTag = event.tags.find(
+    (tag) => tag[0] === "e" && tag[3] === "root"
+  )
+  if (rootTag && rootTag[1]) {
+    return rootTag[1] as EventId
+  }
+  // Fallback: first e tag
+  const firstETag = event.tags.find((tag) => tag[0] === "e")
+  if (firstETag && firstETag[1]) {
+    return firstETag[1] as EventId
+  }
+  return undefined
+}
+
+/**
+ * Get the reply-to event ID from message event tags
+ */
+const getReplyToFromMessage = (event: NostrEvent): EventId | undefined => {
+  const replyTag = event.tags.find(
+    (tag) => tag[0] === "e" && tag[3] === "reply"
+  )
+  if (replyTag && replyTag[1]) {
+    return replyTag[1] as EventId
+  }
+  return undefined
+}
+
+// =============================================================================
+// Service Implementation
+// =============================================================================
+
+const make = Effect.gen(function* () {
+  const relay = yield* RelayService
+  const eventService = yield* EventService
+
+  const createChannel: ChatService["createChannel"] = (params, privateKey) =>
+    Effect.gen(function* () {
+      const content = serializeContent(params.content)
+      const tags = (params.tags ?? []).map((t) => decodeTag([...t]))
+
+      const event = yield* eventService.createEvent(
+        {
+          kind: CHANNEL_CREATE_KIND,
+          content,
+          tags,
+        },
+        privateKey
+      )
+
+      yield* relay.publish(event)
+      return event
+    }).pipe(
+      Effect.mapError(
+        (error) =>
+          new RelayError({
+            message: `Failed to create channel: ${String(error)}`,
+            relay: relay.url,
+          })
+      )
+    )
+
+  const updateChannelMetadata: ChatService["updateChannelMetadata"] = (params, privateKey) =>
+    Effect.gen(function* () {
+      const content = serializeContent(params.content)
+
+      // Build tags: e tag referencing channel creation, optional category tags
+      const tags: typeof Tag.Type[] = []
+
+      // Add e tag with optional relay hint and "root" marker
+      const eTag = ["e", params.channelCreateEventId]
+      if (params.relayUrl) {
+        eTag.push(params.relayUrl, "root")
+      }
+      tags.push(decodeTag(eTag))
+
+      // Add category tags
+      if (params.categories) {
+        for (const category of params.categories) {
+          tags.push(decodeTag(["t", category]))
+        }
+      }
+
+      // Add additional tags
+      if (params.tags) {
+        for (const t of params.tags) {
+          tags.push(decodeTag([...t]))
+        }
+      }
+
+      const event = yield* eventService.createEvent(
+        {
+          kind: CHANNEL_METADATA_KIND,
+          content,
+          tags,
+        },
+        privateKey
+      )
+
+      yield* relay.publish(event)
+      return event
+    }).pipe(
+      Effect.mapError(
+        (error) =>
+          new RelayError({
+            message: `Failed to update channel metadata: ${String(error)}`,
+            relay: relay.url,
+          })
+      )
+    )
+
+  const sendMessage: ChatService["sendMessage"] = (params, privateKey) =>
+    Effect.gen(function* () {
+      const tags: typeof Tag.Type[] = []
+
+      // Root e tag for the channel
+      tags.push(decodeTag(["e", params.channelCreateEventId, params.relayUrl, "root"]))
+
+      // Reply e tag if replying to a message
+      if (params.replyToEventId) {
+        tags.push(decodeTag(["e", params.replyToEventId, params.relayUrl, "reply"]))
+      }
+
+      // p tags for mentioned pubkeys
+      if (params.mentionPubkeys) {
+        for (const pubkey of params.mentionPubkeys) {
+          tags.push(decodeTag(["p", pubkey, params.relayUrl]))
+        }
+      }
+
+      // Additional tags
+      if (params.tags) {
+        for (const t of params.tags) {
+          tags.push(decodeTag([...t]))
+        }
+      }
+
+      const event = yield* eventService.createEvent(
+        {
+          kind: CHANNEL_MESSAGE_KIND,
+          content: params.content,
+          tags,
+        },
+        privateKey
+      )
+
+      yield* relay.publish(event)
+      return event
+    }).pipe(
+      Effect.mapError(
+        (error) =>
+          new RelayError({
+            message: `Failed to send message: ${String(error)}`,
+            relay: relay.url,
+          })
+      )
+    )
+
+  const hideMessage: ChatService["hideMessage"] = (params, privateKey) =>
+    Effect.gen(function* () {
+      const content = serializeContent(params.content)
+
+      const tags: typeof Tag.Type[] = [
+        decodeTag(["e", params.channelMessageEventId]),
+      ]
+
+      if (params.tags) {
+        for (const t of params.tags) {
+          tags.push(decodeTag([...t]))
+        }
+      }
+
+      const event = yield* eventService.createEvent(
+        {
+          kind: CHANNEL_HIDE_MESSAGE_KIND,
+          content,
+          tags,
+        },
+        privateKey
+      )
+
+      yield* relay.publish(event)
+      return event
+    }).pipe(
+      Effect.mapError(
+        (error) =>
+          new RelayError({
+            message: `Failed to hide message: ${String(error)}`,
+            relay: relay.url,
+          })
+      )
+    )
+
+  const muteUser: ChatService["muteUser"] = (params, privateKey) =>
+    Effect.gen(function* () {
+      const content = serializeContent(params.content)
+
+      const tags: typeof Tag.Type[] = [
+        decodeTag(["p", params.pubkeyToMute]),
+      ]
+
+      if (params.tags) {
+        for (const t of params.tags) {
+          tags.push(decodeTag([...t]))
+        }
+      }
+
+      const event = yield* eventService.createEvent(
+        {
+          kind: CHANNEL_MUTE_USER_KIND,
+          content,
+          tags,
+        },
+        privateKey
+      )
+
+      yield* relay.publish(event)
+      return event
+    }).pipe(
+      Effect.mapError(
+        (error) =>
+          new RelayError({
+            message: `Failed to mute user: ${String(error)}`,
+            relay: relay.url,
+          })
+      )
+    )
+
+  const getChannel: ChatService["getChannel"] = (channelId) =>
+    Effect.gen(function* () {
+      // Query for channel creation event
+      const createFilter = decodeFilter({
+        ids: [channelId],
+        kinds: [decodeKind(40)],
+        limit: 1,
+      })
+
+      const createSub = yield* relay.subscribe([createFilter])
+      const maybeCreateEvent = yield* Effect.race(
+        createSub.events.pipe(Stream.runHead),
+        Effect.sleep(500).pipe(Effect.as(Option.none<NostrEvent>()))
+      ).pipe(Effect.catchAll(() => Effect.succeed(Option.none<NostrEvent>())))
+      yield* createSub.unsubscribe()
+
+      if (Option.isNone(maybeCreateEvent)) {
+        return {} as ChannelResult
+      }
+
+      const createEvent = maybeCreateEvent.value
+      const metadata = parseChannelMetadata(createEvent.content)
+
+      // Query for latest metadata update
+      const metadataFilter = decodeFilter({
+        kinds: [decodeKind(41)],
+        authors: [createEvent.pubkey],
+        "#e": [channelId],
+        limit: 1,
+      })
+
+      const metaSub = yield* relay.subscribe([metadataFilter])
+      const maybeMetaEvent = yield* Effect.race(
+        metaSub.events.pipe(Stream.runHead),
+        Effect.sleep(500).pipe(Effect.as(Option.none<NostrEvent>()))
+      ).pipe(Effect.catchAll(() => Effect.succeed(Option.none<NostrEvent>())))
+      yield* metaSub.unsubscribe()
+
+      const latestMetadata = Option.isSome(maybeMetaEvent)
+        ? parseChannelMetadata(maybeMetaEvent.value.content) ?? metadata
+        : metadata
+
+      return {
+        metadata: latestMetadata,
+        createEvent,
+        metadataEvent: Option.isSome(maybeMetaEvent) ? maybeMetaEvent.value : undefined,
+      } as ChannelResult
+    }).pipe(
+      Effect.mapError(
+        (error) =>
+          new RelayError({
+            message: `Failed to get channel: ${String(error)}`,
+            relay: relay.url,
+          })
+      )
+    )
+
+  const getMessages: ChatService["getMessages"] = (channelId, limit = 50) =>
+    Effect.gen(function* () {
+      const filter = decodeFilter({
+        kinds: [decodeKind(42)],
+        "#e": [channelId],
+        limit,
+      })
+
+      const sub = yield* relay.subscribe([filter])
+
+      const events: NostrEvent[] = []
+      const collectEffect = sub.events.pipe(
+        Stream.take(limit),
+        Stream.runForEach((event) =>
+          Effect.sync(() => {
+            events.push(event)
+          })
+        )
+      )
+
+      yield* Effect.race(
+        collectEffect,
+        Effect.sleep(1000)
+      ).pipe(Effect.catchAll(() => Effect.void))
+
+      yield* sub.unsubscribe()
+
+      return events.map((event) => ({
+        event,
+        channelId: getChannelIdFromMessage(event) ?? channelId,
+        content: event.content,
+        replyTo: getReplyToFromMessage(event),
+      })) as readonly ChannelMessage[]
+    }).pipe(
+      Effect.mapError(
+        (error) =>
+          new RelayError({
+            message: `Failed to get messages: ${String(error)}`,
+            relay: relay.url,
+          })
+      )
+    )
+
+  return {
+    _tag: "ChatService" as const,
+    createChannel,
+    updateChannelMetadata,
+    sendMessage,
+    hideMessage,
+    muteUser,
+    getChannel,
+    getMessages,
+  }
+})
+
+// =============================================================================
+// Service Layer
+// =============================================================================
+
+/**
+ * Live layer for ChatService
+ * Requires RelayService and EventService
+ */
+export const ChatServiceLive = Layer.effect(ChatService, make)

--- a/src/core/Schema.ts
+++ b/src/core/Schema.ts
@@ -235,6 +235,25 @@ export type RelayMessage = typeof RelayMessage.Type
 export const AUTH_EVENT_KIND = 22242 as EventKind
 
 // =============================================================================
+// NIP-28 Public Chat Event Kinds
+// =============================================================================
+
+/** Channel creation (NIP-28) */
+export const CHANNEL_CREATE_KIND = 40 as EventKind
+
+/** Channel metadata update (NIP-28) */
+export const CHANNEL_METADATA_KIND = 41 as EventKind
+
+/** Channel message (NIP-28) */
+export const CHANNEL_MESSAGE_KIND = 42 as EventKind
+
+/** Hide message - client-side moderation (NIP-28) */
+export const CHANNEL_HIDE_MESSAGE_KIND = 43 as EventKind
+
+/** Mute user - client-side moderation (NIP-28) */
+export const CHANNEL_MUTE_USER_KIND = 44 as EventKind
+
+// =============================================================================
 // Event Kind Classification (NIP-16/33)
 // =============================================================================
 

--- a/src/relay/core/nip/modules/Nip28Module.ts
+++ b/src/relay/core/nip/modules/Nip28Module.ts
@@ -1,0 +1,55 @@
+/**
+ * NIP-28 Module
+ *
+ * Public Chat - channel creation, messages, and client-side moderation.
+ * This module primarily advertises NIP-28 support in relay info.
+ * The actual event handling is done by standard event storage.
+ *
+ * Event kinds:
+ * - 40: Channel creation
+ * - 41: Channel metadata update
+ * - 42: Channel message
+ * - 43: Hide message (client-side moderation)
+ * - 44: Mute user (client-side moderation)
+ *
+ * @see https://github.com/nostr-protocol/nips/blob/master/28.md
+ */
+import { type NipModule, createModule } from "../NipModule.js"
+import {
+  CHANNEL_CREATE_KIND,
+  CHANNEL_METADATA_KIND,
+  CHANNEL_MESSAGE_KIND,
+  CHANNEL_HIDE_MESSAGE_KIND,
+  CHANNEL_MUTE_USER_KIND,
+} from "../../../../core/Schema.js"
+
+// =============================================================================
+// Module
+// =============================================================================
+
+/**
+ * NIP-28 Module for public chat support
+ *
+ * This module:
+ * - Advertises NIP-28 support in relay info
+ * - Handles kinds 40-44 (channel events)
+ *
+ * Note: NIP-28 is primarily client-side. The relay stores events normally.
+ * Kind 41 (metadata) events don't need special replacement logic since
+ * they reference the original kind 40 event via e-tag, not by kind alone.
+ */
+export const Nip28Module: NipModule = createModule({
+  id: "nip-28",
+  nips: [28],
+  description: "Public Chat: channel creation, messages, and moderation",
+  kinds: [
+    CHANNEL_CREATE_KIND as number,
+    CHANNEL_METADATA_KIND as number,
+    CHANNEL_MESSAGE_KIND as number,
+    CHANNEL_HIDE_MESSAGE_KIND as number,
+    CHANNEL_MUTE_USER_KIND as number,
+  ],
+  // No special policies needed - standard event validation applies
+  policies: [],
+  // No special hooks needed - events are stored normally
+})

--- a/src/relay/core/nip/modules/index.ts
+++ b/src/relay/core/nip/modules/index.ts
@@ -8,6 +8,7 @@
 export { Nip01Module, createNip01Module, type Nip01Config } from "./Nip01Module.js"
 export { Nip11Module, createNip11Module, type Nip11Config } from "./Nip11Module.js"
 export { Nip16Module } from "./Nip16Module.js"
+export { Nip28Module } from "./Nip28Module.js"
 export {
   createNip42Module,
   verifyAuthEvent,


### PR DESCRIPTION
## Summary
- Add NIP-28 event kinds to Schema.ts (kinds 40-44)
- Create ChatService for public chat channel management (client side)
- Create Nip28Module for relay NIP support
- Add 15 new tests with nostr-tools parity
- Document NIP module system in AGENTS.md for future agents

## Files Added
- `src/client/ChatService.ts` - Client service for channel creation, messaging, moderation
- `src/client/ChatService.test.ts` - 15 tests with nostr-tools parity
- `src/relay/core/nip/modules/Nip28Module.ts` - Relay module for NIP-28 support

## Test plan
- [x] `bun run verify` passes (335 tests, +15 new)
- [x] Channel creation (kind 40)
- [x] Channel metadata update (kind 41)
- [x] Channel messaging (kind 42)
- [x] Hide message (kind 43)
- [x] Mute user (kind 44)
- [x] Nip28Module integration with NipRegistry

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)