### PR TITLE
Add NIP-57 Lightning Zaps support

### DIFF
--- a/docs/BUILDOUT.md
+++ b/docs/BUILDOUT.md
@@ -32,7 +32,7 @@ src/
 - **Services**: CryptoService, EventService, Nip44Service (NIP-44 versioned encryption)
 - **Relay**: EventStore, SubscriptionManager, MessageHandler, RelayServer, PolicyPipeline, NIP-16/33 Replaceable Events, NIP-11 Relay Info, NIP Module System, Timestamp Limits, ConnectionManager, NIP-42 Authentication (AuthService)
 - **Relay Backends**: Bun (SQLite), Cloudflare Durable Objects (DO SQLite)
-- **Client**: RelayService (WebSocket connection management), FollowListService (NIP-02), RelayListService (NIP-65), HandlerService (NIP-89), DVMService (NIP-90), ChatService (NIP-28)
+- **Client**: RelayService (WebSocket connection management), FollowListService (NIP-02), RelayListService (NIP-65), HandlerService (NIP-89), DVMService (NIP-90), ChatService (NIP-28), ZapService (NIP-57)
 
 ### Open Issues
 
@@ -172,6 +172,7 @@ src/client/
 ├── RelayListService.ts    # Relay preferences (NIP-65)
 ├── HandlerService.ts      # App handler discovery (NIP-89)
 ├── DVMService.ts          # Data Vending Machine (NIP-90)
+├── ZapService.ts          # Lightning Zaps (NIP-57)
 └── RemoteSignerService.ts # Nostr Connect (NIP-46)
 ```
 
@@ -210,6 +211,7 @@ src/client/
 | NIP-04 | `nip04.test.ts` | - | ⬜ Not planned |
 | NIP-05 | `nip05.test.ts` | `src/client/Nip05Service.test.ts` | ⬜ Not started |
 | NIP-28 | `nip28.test.ts` | `src/client/ChatService.test.ts` | ✅ Done |
+| NIP-57 | `nip57.test.ts` | `src/client/ZapService.test.ts` | ✅ Done |
 
 ### Adding a New NIP
 

--- a/src/client/ZapService.test.ts
+++ b/src/client/ZapService.test.ts
@@ -1,0 +1,627 @@
+/**
+ * Tests for ZapService (NIP-57)
+ *
+ * Test parity with nostr-tools nip57.test.ts
+ */
+import { test, expect, describe, beforeAll, afterAll } from "bun:test"
+import { Effect, Layer } from "effect"
+import { ZapService, ZapServiceLive } from "./ZapService.js"
+import { makeRelayService } from "./RelayService.js"
+import { startTestRelay, type RelayHandle } from "../relay/index.js"
+import { CryptoService, CryptoServiceLive } from "../services/CryptoService.js"
+import { EventService, EventServiceLive } from "../services/EventService.js"
+import type { NostrEvent } from "../core/Schema.js"
+import { ZAP_REQUEST_KIND, ZAP_RECEIPT_KIND } from "../core/Schema.js"
+
+describe("ZapService (NIP-57)", () => {
+  let relay: RelayHandle
+  let port: number
+
+  beforeAll(async () => {
+    port = 13000 + Math.floor(Math.random() * 10000)
+    relay = await startTestRelay(port)
+  })
+
+  afterAll(async () => {
+    await Effect.runPromise(relay.stop())
+  })
+
+  const makeTestLayers = () => {
+    const RelayLayer = makeRelayService({
+      url: `ws://localhost:${port}`,
+      reconnect: false,
+    })
+
+    const ServiceLayer = Layer.merge(
+      CryptoServiceLive,
+      EventServiceLive.pipe(Layer.provide(CryptoServiceLive))
+    )
+
+    return Layer.merge(
+      RelayLayer,
+      Layer.merge(
+        ServiceLayer,
+        ZapServiceLive.pipe(Layer.provide(ServiceLayer))
+      )
+    )
+  }
+
+  describe("validateZapRequest (nostr-tools parity)", () => {
+    test("returns an error message for invalid JSON", async () => {
+      const program = Effect.gen(function* () {
+        const zapService = yield* ZapService
+        const result = yield* zapService.validateZapRequest("invalid JSON")
+        expect(result).toBe("Invalid zap request JSON.")
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+
+    test("returns an error message if the Zap request is not a valid Nostr event", async () => {
+      const program = Effect.gen(function* () {
+        const zapService = yield* ZapService
+
+        const zapRequest = {
+          kind: 1234,
+          created_at: Math.floor(Date.now() / 1000),
+          content: "content",
+          tags: [
+            ["p", "profile"],
+            ["amount", "100"],
+            ["relays", "relay1", "relay2"],
+          ],
+        }
+
+        const result = yield* zapService.validateZapRequest(JSON.stringify(zapRequest))
+        expect(result).toBe("Zap request is not a valid Nostr event.")
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+
+    test("returns an error message if the signature on the Zap request is invalid", async () => {
+      const program = Effect.gen(function* () {
+        const crypto = yield* CryptoService
+        const zapService = yield* ZapService
+
+        const privateKey = yield* crypto.generatePrivateKey()
+        const publicKey = yield* crypto.getPublicKey(privateKey)
+
+        const zapRequest = {
+          id: "0000000000000000000000000000000000000000000000000000000000000000",
+          pubkey: publicKey,
+          kind: 9734,
+          created_at: Math.floor(Date.now() / 1000),
+          content: "content",
+          sig: "0".repeat(128),
+          tags: [
+            ["p", publicKey],
+            ["amount", "100"],
+            ["relays", "relay1", "relay2"],
+          ],
+        }
+
+        const result = yield* zapService.validateZapRequest(JSON.stringify(zapRequest))
+        expect(result).toBe("Invalid signature on zap request.")
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+
+    test("returns an error message if the Zap request does not have a 'p' tag", async () => {
+      const program = Effect.gen(function* () {
+        const crypto = yield* CryptoService
+        const zapService = yield* ZapService
+        const eventService = yield* EventService
+
+        const privateKey = yield* crypto.generatePrivateKey()
+
+        const event = yield* eventService.createEvent(
+          {
+            kind: ZAP_REQUEST_KIND,
+            content: "content",
+            tags: [
+              ["amount", "100"] as unknown as typeof import("../core/Schema.js").Tag.Type,
+              ["relays", "relay1", "relay2"] as unknown as typeof import("../core/Schema.js").Tag.Type,
+            ],
+          },
+          privateKey
+        )
+
+        const result = yield* zapService.validateZapRequest(JSON.stringify(event))
+        expect(result).toBe("Zap request doesn't have a 'p' tag.")
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+
+    test("returns an error message if the 'p' tag on the Zap request is not valid hex", async () => {
+      const program = Effect.gen(function* () {
+        const crypto = yield* CryptoService
+        const zapService = yield* ZapService
+        const eventService = yield* EventService
+
+        const privateKey = yield* crypto.generatePrivateKey()
+
+        const event = yield* eventService.createEvent(
+          {
+            kind: ZAP_REQUEST_KIND,
+            content: "content",
+            tags: [
+              ["p", "invalid hex"] as unknown as typeof import("../core/Schema.js").Tag.Type,
+              ["amount", "100"] as unknown as typeof import("../core/Schema.js").Tag.Type,
+              ["relays", "relay1", "relay2"] as unknown as typeof import("../core/Schema.js").Tag.Type,
+            ],
+          },
+          privateKey
+        )
+
+        const result = yield* zapService.validateZapRequest(JSON.stringify(event))
+        expect(result).toBe("Zap request 'p' tag is not valid hex.")
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+
+    test("returns an error message if the 'e' tag on the Zap request is not valid hex", async () => {
+      const program = Effect.gen(function* () {
+        const crypto = yield* CryptoService
+        const zapService = yield* ZapService
+        const eventService = yield* EventService
+
+        const privateKey = yield* crypto.generatePrivateKey()
+        const publicKey = yield* crypto.getPublicKey(privateKey)
+
+        const event = yield* eventService.createEvent(
+          {
+            kind: ZAP_REQUEST_KIND,
+            content: "content",
+            tags: [
+              ["p", publicKey] as unknown as typeof import("../core/Schema.js").Tag.Type,
+              ["e", "invalid hex"] as unknown as typeof import("../core/Schema.js").Tag.Type,
+              ["amount", "100"] as unknown as typeof import("../core/Schema.js").Tag.Type,
+              ["relays", "relay1", "relay2"] as unknown as typeof import("../core/Schema.js").Tag.Type,
+            ],
+          },
+          privateKey
+        )
+
+        const result = yield* zapService.validateZapRequest(JSON.stringify(event))
+        expect(result).toBe("Zap request 'e' tag is not valid hex.")
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+
+    test("returns an error message if the Zap request does not have a relays tag", async () => {
+      const program = Effect.gen(function* () {
+        const crypto = yield* CryptoService
+        const zapService = yield* ZapService
+        const eventService = yield* EventService
+
+        const privateKey = yield* crypto.generatePrivateKey()
+        const publicKey = yield* crypto.getPublicKey(privateKey)
+
+        const event = yield* eventService.createEvent(
+          {
+            kind: ZAP_REQUEST_KIND,
+            content: "content",
+            tags: [
+              ["p", publicKey] as unknown as typeof import("../core/Schema.js").Tag.Type,
+              ["amount", "100"] as unknown as typeof import("../core/Schema.js").Tag.Type,
+            ],
+          },
+          privateKey
+        )
+
+        const result = yield* zapService.validateZapRequest(JSON.stringify(event))
+        expect(result).toBe("Zap request doesn't have a 'relays' tag.")
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+
+    test("returns null for a valid Zap request", async () => {
+      const program = Effect.gen(function* () {
+        const crypto = yield* CryptoService
+        const zapService = yield* ZapService
+        const eventService = yield* EventService
+
+        const privateKey = yield* crypto.generatePrivateKey()
+        const publicKey = yield* crypto.getPublicKey(privateKey)
+
+        const event = yield* eventService.createEvent(
+          {
+            kind: ZAP_REQUEST_KIND,
+            content: "content",
+            tags: [
+              ["p", publicKey] as unknown as typeof import("../core/Schema.js").Tag.Type,
+              ["amount", "100"] as unknown as typeof import("../core/Schema.js").Tag.Type,
+              ["relays", "relay1", "relay2"] as unknown as typeof import("../core/Schema.js").Tag.Type,
+            ],
+          },
+          privateKey
+        )
+
+        const result = yield* zapService.validateZapRequest(JSON.stringify(event))
+        expect(result).toBeNull()
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+  })
+
+  describe("makeZapReceipt (nostr-tools parity)", () => {
+    test("returns a valid Zap receipt with a preimage", async () => {
+      const program = Effect.gen(function* () {
+        const crypto = yield* CryptoService
+        const zapService = yield* ZapService
+        const eventService = yield* EventService
+
+        const privateKey = yield* crypto.generatePrivateKey()
+        const publicKey = yield* crypto.getPublicKey(privateKey)
+        const target = "efeb5d6e74ce6ffea6cae4094a9f29c26b5c56d7b44fae9f490f3410fd708c45"
+
+        // Create a zap request
+        const zapRequestEvent = yield* eventService.createEvent(
+          {
+            kind: ZAP_REQUEST_KIND,
+            content: "content",
+            tags: [
+              ["p", target] as unknown as typeof import("../core/Schema.js").Tag.Type,
+              ["amount", "100"] as unknown as typeof import("../core/Schema.js").Tag.Type,
+              ["relays", "relay1", "relay2"] as unknown as typeof import("../core/Schema.js").Tag.Type,
+            ],
+          },
+          privateKey
+        )
+
+        const zapRequest = JSON.stringify(zapRequestEvent)
+        const preimage = "preimage"
+        const bolt11 = "bolt11"
+        const paidAt = new Date()
+
+        const result = yield* zapService.makeZapReceipt(
+          { zapRequest, preimage, bolt11, paidAt },
+          privateKey
+        )
+
+        expect(result.kind as number).toBe(ZAP_RECEIPT_KIND as number)
+        expect(result.created_at).toBeCloseTo(paidAt.getTime() / 1000, 0)
+        expect(result.content).toBe("")
+
+        // Check tags
+        const bolt11Tag = result.tags.find(t => t[0] === "bolt11" && t[1] === bolt11)
+        expect(bolt11Tag).toBeDefined()
+
+        const descriptionTag = result.tags.find(t => t[0] === "description" && t[1] === zapRequest)
+        expect(descriptionTag).toBeDefined()
+
+        const pTag = result.tags.find(t => t[0] === "p" && t[1] === target)
+        expect(pTag).toBeDefined()
+
+        const PTag = result.tags.find(t => t[0] === "P" && t[1] === publicKey)
+        expect(PTag).toBeDefined()
+
+        const preimageTag = result.tags.find(t => t[0] === "preimage" && t[1] === preimage)
+        expect(preimageTag).toBeDefined()
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+
+    test("returns a valid Zap receipt without a preimage", async () => {
+      const program = Effect.gen(function* () {
+        const crypto = yield* CryptoService
+        const zapService = yield* ZapService
+        const eventService = yield* EventService
+
+        const privateKey = yield* crypto.generatePrivateKey()
+        const publicKey = yield* crypto.getPublicKey(privateKey)
+        const target = "efeb5d6e74ce6ffea6cae4094a9f29c26b5c56d7b44fae9f490f3410fd708c45"
+
+        // Create a zap request
+        const zapRequestEvent = yield* eventService.createEvent(
+          {
+            kind: ZAP_REQUEST_KIND,
+            content: "content",
+            tags: [
+              ["p", target] as unknown as typeof import("../core/Schema.js").Tag.Type,
+              ["amount", "100"] as unknown as typeof import("../core/Schema.js").Tag.Type,
+              ["relays", "relay1", "relay2"] as unknown as typeof import("../core/Schema.js").Tag.Type,
+            ],
+          },
+          privateKey
+        )
+
+        const zapRequest = JSON.stringify(zapRequestEvent)
+        const bolt11 = "bolt11"
+        const paidAt = new Date()
+
+        const result = yield* zapService.makeZapReceipt(
+          { zapRequest, bolt11, paidAt },
+          privateKey
+        )
+
+        expect(result.kind as number).toBe(ZAP_RECEIPT_KIND as number)
+        expect(result.created_at).toBeCloseTo(paidAt.getTime() / 1000, 0)
+        expect(result.content).toBe("")
+
+        // Check tags
+        const bolt11Tag = result.tags.find(t => t[0] === "bolt11" && t[1] === bolt11)
+        expect(bolt11Tag).toBeDefined()
+
+        const descriptionTag = result.tags.find(t => t[0] === "description")
+        expect(descriptionTag).toBeDefined()
+
+        const pTag = result.tags.find(t => t[0] === "p" && t[1] === target)
+        expect(pTag).toBeDefined()
+
+        const PTag = result.tags.find(t => t[0] === "P" && t[1] === publicKey)
+        expect(PTag).toBeDefined()
+
+        // Should NOT have preimage tag
+        const preimageTag = result.tags.find(t => t[0] === "preimage")
+        expect(preimageTag).toBeUndefined()
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+  })
+
+  describe("getSatoshisAmountFromBolt11 (nostr-tools parity)", () => {
+    test("parses the amount from bolt11 invoices", async () => {
+      const program = Effect.gen(function* () {
+        const zapService = yield* ZapService
+
+        // Test cases from nostr-tools
+        expect(
+          zapService.getSatoshisAmountFromBolt11(
+            "lnbc4u1p5zcarnpp5djng98r73nxu66nxp6gndjkw24q7rdzgp7p80lt0gk4z3h3krkssdq9tfpygcqzzsxqzjcsp58hz3v5qefdm70g5fnm2cn6q9thzpu6m4f5wjqurhur5xzmf9vl3s9qxpqysgq9v6qv86xaruzeak9jjyz54fygrkn526z7xhm0llh8wl44gcgh0rznhjqdswd4cjurzdgh0pgzrfj4sd7f3mf89jd6kadse008ex7kxgqqa5xrk"
+          )
+        ).toEqual(400)
+
+        expect(
+          zapService.getSatoshisAmountFromBolt11(
+            "lnbc8400u1p5zcaz5pp5ltvyhtg4ed7sd8jurj28ugmavezkmqsadpe3t9npufpcrd0uet0scqzyssp5l3hz4ayt5ee0p83ma4a96l2rruhx33eyycewldu2ffa5pk2qx7jq9q7sqqqqqqqqqqqqqqqqqqqsqqqqqysgqdq8w3jhxaqmqz9gxqyjw5qrzjqwryaup9lh50kkranzgcdnn2fgvx390wgj5jd07rwr3vxeje0glclll8qkt3np4rqyqqqqlgqqqqqeqqjqhuhjk5u9r850ncxngne7cfp9s08s2nm6c2rkz7jhl8gjmlx0fga5tlncgeuh4avlsrkq6ljyyhgq8rrxprga03esqhd0gf5455x6tdcqahhw9q"
+          )
+        ).toEqual(840000)
+
+        expect(
+          zapService.getSatoshisAmountFromBolt11(
+            "lnbc210n1p5zcuaxpp52nn778cfk46md4ld0hdj2juuzvfrsrdaf4ek2k0yeensae07x2cqdq9tfpygcqzzsxqzjcsp5768c4k79jtnq92pgppan8rjnujcpcqhnqwqwk3lm5dfr7e0k2a7s9qxpqysgqt8lnh9l7ple27t73x7gty570ltas2s33uahc7egke5tdmhxr3ezn590wf2utxyt7d3afnk2lxc2u0enc6n53ck4mxwpmzpxa7ws05aqp0c5x3r"
+          )
+        ).toEqual(21)
+
+        expect(
+          zapService.getSatoshisAmountFromBolt11(
+            "lnbc899640n1p5zcuavpp5w72fqrf09286lq33vw364qryrq5nw60z4dhdx56f8w05xkx4massdq9tfpygcqzzsxqzjcsp5qrqn4kpvem5jwpl63kj5pfdlqxg2plaffz0prz7vaqjy29uc66us9qxpqysgqlhzzqmn2jxd2476404krm8nvrarymwq7nj2zecl92xug54ek0mfntdxvxwslf756m8kq0r7jtpantm52fmewc72r5lfmd85505jnemgqw5j0pc"
+          )
+        ).toEqual(89964)
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+  })
+
+  describe("makeZapRequest", () => {
+    test("creates a zap request for a profile", async () => {
+      const program = Effect.gen(function* () {
+        const crypto = yield* CryptoService
+        const zapService = yield* ZapService
+
+        const privateKey = yield* crypto.generatePrivateKey()
+        const recipientPubkey = "efeb5d6e74ce6ffea6cae4094a9f29c26b5c56d7b44fae9f490f3410fd708c45"
+
+        const event = yield* zapService.makeZapRequest(
+          {
+            pubkey: recipientPubkey,
+            amount: 21000,
+            relays: ["wss://relay1.example.com", "wss://relay2.example.com"],
+            comment: "Great post!",
+          },
+          privateKey
+        )
+
+        expect(event.kind as number).toBe(ZAP_REQUEST_KIND as number)
+        expect(event.content).toBe("Great post!")
+
+        // Check p tag
+        const pTag = event.tags.find(t => t[0] === "p" && t[1] === recipientPubkey)
+        expect(pTag).toBeDefined()
+
+        // Check amount tag
+        const amountTag = event.tags.find(t => t[0] === "amount" && t[1] === "21000")
+        expect(amountTag).toBeDefined()
+
+        // Check relays tag
+        const relaysTag = event.tags.find(t => t[0] === "relays")
+        expect(relaysTag).toBeDefined()
+        expect(relaysTag).toContain("wss://relay1.example.com")
+        expect(relaysTag).toContain("wss://relay2.example.com")
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+
+    test("creates a zap request for an event", async () => {
+      const program = Effect.gen(function* () {
+        const crypto = yield* CryptoService
+        const zapService = yield* ZapService
+        const eventService = yield* EventService
+
+        const privateKey = yield* crypto.generatePrivateKey()
+        const targetPubkey = "efeb5d6e74ce6ffea6cae4094a9f29c26b5c56d7b44fae9f490f3410fd708c45"
+
+        // Create a target event to zap (normal kind 1 note)
+        const targetEvent = yield* eventService.createEvent(
+          {
+            kind: 1 as typeof ZAP_REQUEST_KIND,
+            content: "Hello Nostr!",
+            tags: [],
+          },
+          privateKey
+        )
+        // Override pubkey for test
+        const fakeTargetEvent = { ...targetEvent, pubkey: targetPubkey }
+
+        const event = yield* zapService.makeZapRequest(
+          {
+            event: fakeTargetEvent as unknown as NostrEvent,
+            amount: 100000,
+            relays: ["wss://relay.example.com"],
+            comment: "Zapping this note!",
+          },
+          privateKey
+        )
+
+        expect(event.kind as number).toBe(ZAP_REQUEST_KIND as number)
+
+        // Check p tag (from event author)
+        const pTag = event.tags.find(t => t[0] === "p" && t[1] === targetPubkey)
+        expect(pTag).toBeDefined()
+
+        // Check e tag (event id)
+        const eTag = event.tags.find(t => t[0] === "e")
+        expect(eTag).toBeDefined()
+
+        // Check k tag (event kind)
+        const kTag = event.tags.find(t => t[0] === "k" && t[1] === "1")
+        expect(kTag).toBeDefined()
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+
+    test("includes lnurl tag when provided", async () => {
+      const program = Effect.gen(function* () {
+        const crypto = yield* CryptoService
+        const zapService = yield* ZapService
+
+        const privateKey = yield* crypto.generatePrivateKey()
+        const recipientPubkey = "efeb5d6e74ce6ffea6cae4094a9f29c26b5c56d7b44fae9f490f3410fd708c45"
+        const lnurl = "lnurl1dp68gurn8ghj7um9wfmxjcm99e3k7mf0v9cxj0m385ekvcenxc6r2c35xvukxefcv5mkvv34x5ekzd3ev56nyd3hxqurzepexejxxepnxscrvwfnv9nxzcn9xq6xyefhvgcxxcmyxymnserxfq5fns"
+
+        const event = yield* zapService.makeZapRequest(
+          {
+            pubkey: recipientPubkey,
+            amount: 21000,
+            relays: ["wss://relay.example.com"],
+            lnurl,
+          },
+          privateKey
+        )
+
+        const lnurlTag = event.tags.find(t => t[0] === "lnurl" && t[1] === lnurl)
+        expect(lnurlTag).toBeDefined()
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+  })
+
+  describe("getZapEndpoint", () => {
+    test("extracts endpoint from lud16 (lightning address)", async () => {
+      const program = Effect.gen(function* () {
+        const crypto = yield* CryptoService
+        const zapService = yield* ZapService
+        const eventService = yield* EventService
+
+        const privateKey = yield* crypto.generatePrivateKey()
+
+        // Create a metadata event with lud16
+        const metadata = yield* eventService.createEvent(
+          {
+            kind: 0 as typeof ZAP_REQUEST_KIND,
+            content: JSON.stringify({
+              name: "Test User",
+              lud16: "user@example.com",
+            }),
+            tags: [],
+          },
+          privateKey
+        )
+
+        const endpoint = yield* zapService.getZapEndpoint(metadata)
+        expect(endpoint).toBe("https://example.com/.well-known/lnurlp/user")
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+
+    test("returns null for invalid metadata", async () => {
+      const program = Effect.gen(function* () {
+        const crypto = yield* CryptoService
+        const zapService = yield* ZapService
+        const eventService = yield* EventService
+
+        const privateKey = yield* crypto.generatePrivateKey()
+
+        const metadata = yield* eventService.createEvent(
+          {
+            kind: 0 as typeof ZAP_REQUEST_KIND,
+            content: "not valid json{",
+            tags: [],
+          },
+          privateKey
+        )
+
+        const endpoint = yield* zapService.getZapEndpoint(metadata)
+        expect(endpoint).toBeNull()
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+
+    test("returns null for metadata without lightning info", async () => {
+      const program = Effect.gen(function* () {
+        const crypto = yield* CryptoService
+        const zapService = yield* ZapService
+        const eventService = yield* EventService
+
+        const privateKey = yield* crypto.generatePrivateKey()
+
+        const metadata = yield* eventService.createEvent(
+          {
+            kind: 0 as typeof ZAP_REQUEST_KIND,
+            content: JSON.stringify({ name: "No Lightning User" }),
+            tags: [],
+          },
+          privateKey
+        )
+
+        const endpoint = yield* zapService.getZapEndpoint(metadata)
+        expect(endpoint).toBeNull()
+      })
+
+      await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+    })
+  })
+})
+
+describe("Nip57Module", () => {
+  test("has correct module configuration", async () => {
+    const { Nip57Module } = await import("../relay/core/nip/modules/Nip57Module.js")
+
+    expect(Nip57Module.id).toBe("nip-57")
+    expect(Nip57Module.nips).toContain(57)
+    expect(Nip57Module.kinds).toContain(ZAP_REQUEST_KIND as number)
+    expect(Nip57Module.kinds).toContain(ZAP_RECEIPT_KIND as number)
+  })
+
+  test("integrates with NipRegistry", async () => {
+    const { Nip57Module } = await import("../relay/core/nip/modules/Nip57Module.js")
+    const { NipRegistryLive, NipRegistry } = await import("../relay/core/nip/index.js")
+    const { Effect } = await import("effect")
+
+    const program = Effect.gen(function* () {
+      const registry = yield* NipRegistry
+      expect(registry.supportedNips).toContain(57)
+      expect(registry.hasModule("nip-57")).toBe(true)
+    })
+
+    await Effect.runPromise(
+      program.pipe(Effect.provide(NipRegistryLive([Nip57Module])))
+    )
+  })
+})

--- a/src/client/ZapService.ts
+++ b/src/client/ZapService.ts
@@ -1,0 +1,405 @@
+/**
+ * ZapService
+ *
+ * NIP-57 Lightning Zaps service.
+ * Handles zap requests, receipts, and LNURL integration.
+ *
+ * @see https://github.com/nostr-protocol/nips/blob/master/57.md
+ */
+import { Context, Effect, Layer } from "effect"
+import { Schema } from "@effect/schema"
+import { bech32 } from "@scure/base"
+import { EventService } from "../services/EventService.js"
+import { CryptoError, InvalidPrivateKey, InvalidPublicKey } from "../core/Errors.js"
+import {
+  type NostrEvent,
+  type PrivateKey,
+  Tag,
+  ZAP_REQUEST_KIND,
+  ZAP_RECEIPT_KIND,
+  isReplaceableKind,
+  isParameterizedReplaceableKind,
+  getDTagValue,
+} from "../core/Schema.js"
+
+// =============================================================================
+// Types
+// =============================================================================
+
+const decodeTag = Schema.decodeSync(Tag)
+
+/** LNURL pay endpoint response */
+export interface LnurlPayResponse {
+  /** Whether this endpoint allows Nostr zaps */
+  readonly allowsNostr?: boolean
+  /** The nostr pubkey of the LNURL server (for signing zap receipts) */
+  readonly nostrPubkey?: string
+  /** The callback URL to fetch invoices from */
+  readonly callback: string
+  /** Minimum sendable amount in millisats */
+  readonly minSendable: number
+  /** Maximum sendable amount in millisats */
+  readonly maxSendable: number
+}
+
+/** Parameters for creating a zap request to a profile */
+export interface ProfileZapParams {
+  /** The pubkey of the recipient */
+  readonly pubkey: string
+  /** Amount in millisats */
+  readonly amount: number
+  /** Optional comment to include */
+  readonly comment?: string
+  /** Relays for the zap receipt */
+  readonly relays: readonly string[]
+  /** Optional lnurl (bech32 encoded) */
+  readonly lnurl?: string
+}
+
+/** Parameters for creating a zap request to an event */
+export interface EventZapParams {
+  /** The event to zap */
+  readonly event: NostrEvent
+  /** Amount in millisats */
+  readonly amount: number
+  /** Optional comment to include */
+  readonly comment?: string
+  /** Relays for the zap receipt */
+  readonly relays: readonly string[]
+  /** Optional lnurl (bech32 encoded) */
+  readonly lnurl?: string
+}
+
+/** Parameters for creating a zap receipt */
+export interface ZapReceiptParams {
+  /** The JSON-encoded zap request */
+  readonly zapRequest: string
+  /** The bolt11 invoice */
+  readonly bolt11: string
+  /** When the invoice was paid */
+  readonly paidAt: Date
+  /** Optional preimage */
+  readonly preimage?: string
+}
+
+/** Validation error for zap requests */
+export type ZapValidationError =
+  | "Invalid zap request JSON."
+  | "Zap request is not a valid Nostr event."
+  | "Invalid signature on zap request."
+  | "Zap request doesn't have a 'p' tag."
+  | "Zap request 'p' tag is not valid hex."
+  | "Zap request 'e' tag is not valid hex."
+  | "Zap request doesn't have a 'relays' tag."
+
+// =============================================================================
+// Service Interface
+// =============================================================================
+
+export interface ZapService {
+  readonly _tag: "ZapService"
+
+  /**
+   * Get the LNURL pay endpoint from profile metadata
+   * Parses lud16 (lightning address) or lud06 (lnurl)
+   */
+  getZapEndpoint(
+    metadata: NostrEvent
+  ): Effect.Effect<string | null>
+
+  /**
+   * Create a zap request event (kind 9734)
+   * This event is NOT published, but sent to the LNURL callback
+   */
+  makeZapRequest(
+    params: ProfileZapParams | EventZapParams,
+    privateKey: PrivateKey
+  ): Effect.Effect<NostrEvent, CryptoError | InvalidPrivateKey>
+
+  /**
+   * Validate a zap request JSON string
+   * Returns null if valid, error message if invalid
+   */
+  validateZapRequest(zapRequestString: string): Effect.Effect<ZapValidationError | null, CryptoError | InvalidPublicKey>
+
+  /**
+   * Create a zap receipt event (kind 9735)
+   * This is created by the LNURL server after payment
+   */
+  makeZapReceipt(
+    params: ZapReceiptParams,
+    privateKey: PrivateKey
+  ): Effect.Effect<NostrEvent, CryptoError | InvalidPrivateKey>
+
+  /**
+   * Parse the satoshi amount from a bolt11 invoice
+   */
+  getSatoshisAmountFromBolt11(bolt11: string): number
+}
+
+// =============================================================================
+// Service Tag
+// =============================================================================
+
+export const ZapService = Context.GenericTag<ZapService>("ZapService")
+
+// =============================================================================
+// Helper Functions
+// =============================================================================
+
+/**
+ * Decode LNURL (bech32-encoded URL)
+ */
+const decodeLnurl = (lnurl: string): string => {
+  const { words } = bech32.decode(lnurl as `${string}1${string}`, 1000)
+  const data = bech32.fromWords(words)
+  return new TextDecoder().decode(new Uint8Array(data))
+}
+
+/**
+ * Parse satoshi amount from bolt11 invoice
+ * Based on nostr-tools implementation
+ */
+const parseBolt11Amount = (bolt11: string): number => {
+  if (bolt11.length < 50) {
+    return 0
+  }
+  bolt11 = bolt11.substring(0, 50)
+  const idx = bolt11.lastIndexOf("1")
+  if (idx === -1) {
+    return 0
+  }
+  const hrp = bolt11.substring(0, idx)
+  if (!hrp.startsWith("lnbc")) {
+    return 0
+  }
+  const amount = hrp.substring(4)
+
+  if (amount.length < 1) {
+    return 0
+  }
+
+  const char = amount[amount.length - 1]!
+  const digit = char.charCodeAt(0) - "0".charCodeAt(0)
+  const isDigit = digit >= 0 && digit <= 9
+
+  let cutPoint = amount.length - 1
+  if (isDigit) {
+    cutPoint++
+  }
+
+  if (cutPoint < 1) {
+    return 0
+  }
+
+  const num = parseInt(amount.substring(0, cutPoint))
+
+  switch (char) {
+    case "m":
+      return num * 100000
+    case "u":
+      return num * 100
+    case "n":
+      return num / 10
+    case "p":
+      return num / 10000
+    default:
+      return num * 100000000
+  }
+}
+
+/**
+ * Check if a string is valid 64-character hex
+ */
+const isValidHex64 = (s: string): boolean => /^[a-f0-9]{64}$/.test(s)
+
+// =============================================================================
+// Service Implementation
+// =============================================================================
+
+const make = Effect.gen(function* () {
+  const eventService = yield* EventService
+
+  const getZapEndpoint: ZapService["getZapEndpoint"] = (metadata) =>
+    Effect.sync(() => {
+      try {
+        const { lud06, lud16 } = JSON.parse(metadata.content)
+
+        let lnurl: string = ""
+        if (lud16) {
+          const [name, domain] = lud16.split("@")
+          if (name && domain) {
+            lnurl = new URL(`/.well-known/lnurlp/${name}`, `https://${domain}`).toString()
+          }
+        } else if (lud06) {
+          lnurl = decodeLnurl(lud06)
+        }
+
+        if (!lnurl) {
+          return null
+        }
+
+        // Note: The actual HTTP fetch would be done by the caller
+        // This just returns the LNURL endpoint URL
+        return lnurl
+      } catch {
+        return null
+      }
+    })
+
+  const makeZapRequest: ZapService["makeZapRequest"] = (params, privateKey) =>
+    Effect.gen(function* () {
+      const tags: typeof Tag.Type[] = []
+
+      // p tag - recipient pubkey
+      const recipientPubkey = "pubkey" in params ? params.pubkey : params.event.pubkey
+      tags.push(decodeTag(["p", recipientPubkey]))
+
+      // amount tag
+      tags.push(decodeTag(["amount", params.amount.toString()]))
+
+      // relays tag
+      tags.push(decodeTag(["relays", ...params.relays]))
+
+      // lnurl tag (optional)
+      if (params.lnurl) {
+        tags.push(decodeTag(["lnurl", params.lnurl]))
+      }
+
+      // If zapping an event, add e tag and possibly a tag
+      if ("event" in params) {
+        tags.push(decodeTag(["e", params.event.id]))
+
+        // Add 'a' tag for replaceable/addressable events
+        if (isReplaceableKind(params.event.kind)) {
+          const a = `${params.event.kind}:${params.event.pubkey}:`
+          tags.push(decodeTag(["a", a]))
+        } else if (isParameterizedReplaceableKind(params.event.kind)) {
+          const d = getDTagValue(params.event) ?? ""
+          const a = `${params.event.kind}:${params.event.pubkey}:${d}`
+          tags.push(decodeTag(["a", a]))
+        }
+
+        // Add k tag for event kind
+        tags.push(decodeTag(["k", params.event.kind.toString()]))
+      }
+
+      const event = yield* eventService.createEvent(
+        {
+          kind: ZAP_REQUEST_KIND,
+          content: params.comment ?? "",
+          tags,
+        },
+        privateKey
+      )
+
+      return event
+    })
+
+  const validateZapRequest: ZapService["validateZapRequest"] = (zapRequestString) =>
+    Effect.gen(function* () {
+      let zapRequest: NostrEvent
+
+      try {
+        zapRequest = JSON.parse(zapRequestString)
+      } catch {
+        return "Invalid zap request JSON." as ZapValidationError
+      }
+
+      // Check basic event structure
+      if (!zapRequest.id || !zapRequest.pubkey || !zapRequest.sig || !zapRequest.kind || !zapRequest.tags) {
+        return "Zap request is not a valid Nostr event." as ZapValidationError
+      }
+
+      // Verify signature
+      const isValid = yield* eventService.verifyEvent(zapRequest)
+      if (!isValid) {
+        return "Invalid signature on zap request." as ZapValidationError
+      }
+
+      // Check for p tag
+      const pTag = zapRequest.tags.find((t) => t[0] === "p" && t[1])
+      if (!pTag) {
+        return "Zap request doesn't have a 'p' tag." as ZapValidationError
+      }
+      if (!isValidHex64(pTag[1]!)) {
+        return "Zap request 'p' tag is not valid hex." as ZapValidationError
+      }
+
+      // Check for e tag (if present)
+      const eTag = zapRequest.tags.find((t) => t[0] === "e" && t[1])
+      if (eTag && !isValidHex64(eTag[1]!)) {
+        return "Zap request 'e' tag is not valid hex." as ZapValidationError
+      }
+
+      // Check for relays tag
+      const relaysTag = zapRequest.tags.find((t) => t[0] === "relays" && t[1])
+      if (!relaysTag) {
+        return "Zap request doesn't have a 'relays' tag." as ZapValidationError
+      }
+
+      return null
+    })
+
+  const makeZapReceipt: ZapService["makeZapReceipt"] = (params, privateKey) =>
+    Effect.gen(function* () {
+      const zapRequest: NostrEvent = JSON.parse(params.zapRequest)
+
+      // Extract tags from zap request (e, p, a)
+      const tagsFromZapRequest = zapRequest.tags.filter(
+        (t) => t[0] === "e" || t[0] === "p" || t[0] === "a"
+      )
+
+      const tags: typeof Tag.Type[] = tagsFromZapRequest.map((t) => decodeTag([...t]))
+
+      // Add P tag (sender's pubkey from zap request)
+      tags.push(decodeTag(["P", zapRequest.pubkey]))
+
+      // Add bolt11 tag
+      tags.push(decodeTag(["bolt11", params.bolt11]))
+
+      // Add description tag (the zap request JSON)
+      tags.push(decodeTag(["description", params.zapRequest]))
+
+      // Add preimage tag if provided
+      if (params.preimage) {
+        tags.push(decodeTag(["preimage", params.preimage]))
+      }
+
+      // Use paidAt timestamp for idempotency (same payment always produces same event)
+      const timestamp = Math.round(params.paidAt.getTime() / 1000)
+      const event = yield* eventService.createEvent(
+        {
+          kind: ZAP_RECEIPT_KIND,
+          content: "",
+          tags,
+          created_at: timestamp as typeof import("../core/Schema.js").UnixTimestamp.Type,
+        },
+        privateKey
+      )
+
+      return event
+    })
+
+  const getSatoshisAmountFromBolt11: ZapService["getSatoshisAmountFromBolt11"] = (bolt11) =>
+    parseBolt11Amount(bolt11)
+
+  return {
+    _tag: "ZapService" as const,
+    getZapEndpoint,
+    makeZapRequest,
+    validateZapRequest,
+    makeZapReceipt,
+    getSatoshisAmountFromBolt11,
+  }
+})
+
+// =============================================================================
+// Service Layer
+// =============================================================================
+
+/**
+ * Live layer for ZapService
+ * Requires EventService
+ */
+export const ZapServiceLive = Layer.effect(ZapService, make)

--- a/src/core/Schema.ts
+++ b/src/core/Schema.ts
@@ -254,6 +254,16 @@ export const CHANNEL_HIDE_MESSAGE_KIND = 43 as EventKind
 export const CHANNEL_MUTE_USER_KIND = 44 as EventKind
 
 // =============================================================================
+// NIP-57 Lightning Zaps Event Kinds
+// =============================================================================
+
+/** Zap request - sent to LNURL endpoint (NIP-57) */
+export const ZAP_REQUEST_KIND = 9734 as EventKind
+
+/** Zap receipt - published after payment (NIP-57) */
+export const ZAP_RECEIPT_KIND = 9735 as EventKind
+
+// =============================================================================
 // Event Kind Classification (NIP-16/33)
 // =============================================================================
 

--- a/src/relay/core/nip/modules/Nip57Module.ts
+++ b/src/relay/core/nip/modules/Nip57Module.ts
@@ -1,0 +1,49 @@
+/**
+ * NIP-57 Module
+ *
+ * Lightning Zaps - zap requests and receipts.
+ * This module primarily advertises NIP-57 support in relay info.
+ * The actual zap flow involves LNURL servers.
+ *
+ * Event kinds:
+ * - 9734: Zap request (typically not published to relays, sent to LNURL callback)
+ * - 9735: Zap receipt (published by LNURL server after payment)
+ *
+ * @see https://github.com/nostr-protocol/nips/blob/master/57.md
+ */
+import { type NipModule, createModule } from "../NipModule.js"
+import {
+  ZAP_REQUEST_KIND,
+  ZAP_RECEIPT_KIND,
+} from "../../../../core/Schema.js"
+
+// =============================================================================
+// Module
+// =============================================================================
+
+/**
+ * NIP-57 Module for Lightning Zaps support
+ *
+ * This module:
+ * - Advertises NIP-57 support in relay info
+ * - Handles kinds 9734 and 9735
+ *
+ * Note: Zap requests (9734) are typically NOT published to relays.
+ * They are sent directly to the LNURL callback. However, relays
+ * may receive them for validation purposes.
+ *
+ * Zap receipts (9735) ARE published to relays by the LNURL server
+ * after payment, so clients can query for them.
+ */
+export const Nip57Module: NipModule = createModule({
+  id: "nip-57",
+  nips: [57],
+  description: "Lightning Zaps: zap requests and receipts",
+  kinds: [
+    ZAP_REQUEST_KIND as number,
+    ZAP_RECEIPT_KIND as number,
+  ],
+  // No special policies needed - standard event validation applies
+  policies: [],
+  // No special hooks needed - events are stored normally
+})

--- a/src/relay/core/nip/modules/index.ts
+++ b/src/relay/core/nip/modules/index.ts
@@ -9,6 +9,7 @@ export { Nip01Module, createNip01Module, type Nip01Config } from "./Nip01Module.
 export { Nip11Module, createNip11Module, type Nip11Config } from "./Nip11Module.js"
 export { Nip16Module } from "./Nip16Module.js"
 export { Nip28Module } from "./Nip28Module.js"
+export { Nip57Module } from "./Nip57Module.js"
 export {
   createNip42Module,
   verifyAuthEvent,


### PR DESCRIPTION
## Summary
- Implements NIP-57 Lightning Zaps for both client and relay
- **Client (ZapService)**: getZapEndpoint, makeZapRequest, validateZapRequest, makeZapReceipt, getSatoshisAmountFromBolt11
- **Relay (Nip57Module)**: Advertises NIP-57 support, handles kinds 9734/9735
- 19 tests with nostr-tools parity

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun test` passes (354 tests, including 19 new NIP-57 tests)
- [x] Tests cover validateZapRequest, makeZapReceipt, getSatoshisAmountFromBolt11 (parity with nostr-tools)
- [x] Tests cover makeZapRequest, getZapEndpoint

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)