### PR TITLE
feat(nip-50): Search capability (filter.search) + tests

### DIFF
--- a/docs/SUPPORTED_NIPS.md
+++ b/docs/SUPPORTED_NIPS.md
@@ -55,6 +55,7 @@ Keep this file up to date whenever adding or removing support.
 | 88 | Polls | `~/code/nips/88.md` | `src/client/Nip88Service.ts` | `src/client/Nip88Service.test.ts` |
 | 51 | Lists | `~/code/nips/51.md` | `src/client/Nip51Service.ts` | `src/client/Nip51Service.test.ts` |
 | 45 | Event counts | `~/code/nips/45.md` | `src/client/Nip45Service.ts`, `src/relay/core/MessageHandler.ts` | `src/client/Nip45Service.test.ts` |
+| 50 | Search capability | `~/code/nips/50.md` | `src/relay/core/FilterMatcher.ts` | `src/client/Nip50Service.test.ts` |
 | 94 | File metadata | `~/code/nips/94.md` | `src/core/Nip94.ts`, `src/wrappers/nip94.ts` | `src/core/Nip94.test.ts` |
 | 98 | HTTP auth | `~/code/nips/98.md` | `src/wrappers/nip98.ts` | `src/core/Nip98.test.ts` |
 | 99 | Classified listings | `~/code/nips/99.md` | `src/wrappers/nip99.ts` | `src/core/Nip99.test.ts` |

--- a/src/client/Nip50Service.test.ts
+++ b/src/client/Nip50Service.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Tests for NIP-50 (Search Capability via filter.search)
+ */
+import { test, expect, describe, beforeAll, afterAll } from "bun:test"
+import { Effect, Layer, Stream, Option } from "effect"
+import { RelayService, makeRelayService } from "./RelayService.js"
+import { startTestRelay, type RelayHandle } from "../relay/index.js"
+import { CryptoService, CryptoServiceLive } from "../services/CryptoService.js"
+import { EventService, EventServiceLive } from "../services/EventService.js"
+import { Schema } from "@effect/schema"
+import { EventKind, Filter } from "../core/Schema.js"
+
+const decodeKind = Schema.decodeSync(EventKind)
+const decodeFilter = Schema.decodeSync(Filter)
+
+describe("NIP-50 Search", () => {
+  let relay: RelayHandle
+  let port: number
+
+  beforeAll(async () => {
+    port = 29000 + Math.floor(Math.random() * 10000)
+    relay = await startTestRelay(port)
+  })
+
+  afterAll(async () => {
+    await Effect.runPromise(relay.stop())
+  })
+
+  const makeTestLayers = () => {
+    const RelayLayer = makeRelayService({ url: `ws://localhost:${port}`, reconnect: false })
+    const ServiceLayer = Layer.merge(
+      CryptoServiceLive,
+      EventServiceLive.pipe(Layer.provide(CryptoServiceLive))
+    )
+    return Layer.merge(RelayLayer, ServiceLayer)
+  }
+
+  test("search content substring", async () => {
+    const program = Effect.gen(function* () {
+      const relayService = yield* RelayService
+      const crypto = yield* CryptoService
+      const events = yield* EventService
+      yield* relayService.connect()
+
+      const sk = yield* crypto.generatePrivateKey()
+
+      const contents = [
+        "Yaks are amazing animals.",
+        "This post is about nostr and Effect.",
+        "yak milk and yak wool", // lower case
+      ]
+      for (const c of contents) {
+        const e = yield* events.createEvent(
+          { kind: decodeKind(1), content: c, tags: [] },
+          sk
+        )
+        const res = yield* relayService.publish(e)
+        expect(res.accepted).toBe(true)
+      }
+
+      // search for 'yak' (case-insensitive): should match 2 events
+      const filter = decodeFilter({ kinds: [decodeKind(1)], search: "yak", limit: 10 })
+      const sub = yield* relayService.subscribe([filter])
+
+      const found: string[] = []
+      // collect up to 2 matching events quickly
+      for (let i = 0; i < 2; i++) {
+        const next = yield* Effect.race(
+          sub.events.pipe(Stream.runHead),
+          Effect.sleep(300).pipe(Effect.as(Option.none()))
+        )
+        if (Option.isSome(next)) found.push(next.value.content)
+      }
+
+      expect(found.length).toBeGreaterThanOrEqual(2)
+      expect(found.some((c) => c.toLowerCase().includes("yak")).valueOf()).toBe(true)
+
+      yield* sub.unsubscribe()
+      yield* relayService.disconnect()
+    })
+
+    await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+  })
+})
+

--- a/src/core/Schema.ts
+++ b/src/core/Schema.ts
@@ -116,6 +116,8 @@ export const Filter = Schema.Struct({
   since: Schema.optional(UnixTimestamp),
   until: Schema.optional(UnixTimestamp),
   limit: Schema.optional(Schema.Number.pipe(Schema.int(), Schema.positive())),
+  // NIP-50 search capability
+  search: Schema.optional(Schema.String),
   // Tag filters (#e, #p, #a, #d, #t, etc.)
   "#e": Schema.optional(Schema.Array(EventId)),
   "#p": Schema.optional(Schema.Array(PublicKey)),

--- a/src/relay/core/FilterMatcher.ts
+++ b/src/relay/core/FilterMatcher.ts
@@ -51,6 +51,12 @@ export const matchesFilter = (event: NostrEvent, filter: Filter): boolean => {
     }
   }
 
+  // NIP-50: basic search on content (case-insensitive substring)
+  if (filter.search && filter.search.trim().length > 0) {
+    const needle = filter.search.toLowerCase()
+    if (!event.content.toLowerCase().includes(needle)) return false
+  }
+
   return true
 }
 


### PR DESCRIPTION
Implements NIP-50 (Search Capability):\n\n- Adds optional 'search' to Filter schema\n- Relay FilterMatcher checks content case-insensitively when 'search' present\n- Test: verifies search finds content with substring matches\n- Docs: SUPPORTED_NIPS.md updated\n\nVerification\n- bun run verify (tsc + bun test) passes