### PR TITLE
feat(nip-31): alt tag helpers + tests

### DIFF
--- a/docs/SUPPORTED_NIPS.md
+++ b/docs/SUPPORTED_NIPS.md
@@ -57,6 +57,7 @@ Keep this file up to date whenever adding or removing support.
 | 45 | Event counts | `~/code/nips/45.md` | `src/client/Nip45Service.ts`, `src/relay/core/MessageHandler.ts` | `src/client/Nip45Service.test.ts` |
 | 50 | Search capability | `~/code/nips/50.md` | `src/relay/core/FilterMatcher.ts` | `src/client/Nip50Service.test.ts` |
 | 09 | Event deletion | `~/code/nips/09.md` | `src/relay/core/MessageHandler.ts` | `src/relay/Nip09Deletion.test.ts` |
+| 31 | Unknown kinds (alt tag) | `~/code/nips/31.md` | `src/wrappers/nip31.ts` | `src/wrappers/nip31.test.ts` |
 | 94 | File metadata | `~/code/nips/94.md` | `src/core/Nip94.ts`, `src/wrappers/nip94.ts` | `src/core/Nip94.test.ts` |
 | 98 | HTTP auth | `~/code/nips/98.md` | `src/wrappers/nip98.ts` | `src/core/Nip98.test.ts` |
 | 99 | Classified listings | `~/code/nips/99.md` | `src/wrappers/nip99.ts` | `src/core/Nip99.test.ts` |

--- a/src/wrappers/nip31.test.ts
+++ b/src/wrappers/nip31.test.ts
@@ -1,0 +1,31 @@
+import { test, expect, describe } from "bun:test"
+import { withAltTag, getAltTag } from "./nip31.js"
+
+describe("NIP-31 alt tag helpers", () => {
+  test("withAltTag adds/replaces alt", () => {
+    const tags: string[][] = [["p", "abc"]]
+    const t1 = withAltTag(tags as any, "Custom Event: Action")
+    expect(t1.find((t) => t[0] === "alt")?.[1]).toBe("Custom Event: Action")
+
+    const t2 = withAltTag(t1 as any, "Updated Summary")
+    const alts = t2.filter((t) => t[0] === "alt")
+    expect(alts.length).toBe(1)
+    expect(alts[0]?.[1]).toBe("Updated Summary")
+  })
+
+  test("getAltTag returns value or null", () => {
+    const event = {
+      id: "e".repeat(64),
+      pubkey: "a".repeat(64),
+      created_at: 123,
+      kind: 40000,
+      content: "",
+      tags: [["alt", "Summary"], ["x", "y"]],
+      sig: "f".repeat(128),
+    } as any
+    expect(getAltTag(event)).toBe("Summary")
+    const event2 = { ...event, tags: [["x", "y"]] }
+    expect(getAltTag(event2 as any)).toBeNull()
+  })
+})
+

--- a/src/wrappers/nip31.ts
+++ b/src/wrappers/nip31.ts
@@ -1,0 +1,19 @@
+/**
+ * NIP-31: Dealing with unknown event kinds (alt tag)
+ *
+ * Provides helpers to add and read the `alt` tag that gives a
+ * human-readable summary for non-kind-1 custom events.
+ */
+import type { Tag, NostrEvent } from "../core/Schema.js"
+
+/** Add or replace the `alt` tag in a tag list */
+export function withAltTag(tags: Tag[], alt: string): Tag[] {
+  const filtered = tags.filter((t) => t[0] !== "alt")
+  return [...filtered, ["alt", alt] as unknown as Tag]
+}
+
+/** Get the `alt` tag value from an event, if present */
+export function getAltTag(event: NostrEvent): string | null {
+  const t = event.tags.find((x) => x[0] === "alt")
+  return t?.[1] ?? null
+}


### PR DESCRIPTION
Implements NIP-31 (alt tag):\n\n- Adds wrappers/nip31.ts with withAltTag/getAltTag\n- Tests in wrappers/nip31.test.ts\n- Updates SUPPORTED_NIPS.md\n\nVerification\n- bun run verify passes