### PR TITLE
feat(nip-14): subject tag helpers + tests

### DIFF
--- a/docs/SUPPORTED_NIPS.md
+++ b/docs/SUPPORTED_NIPS.md
@@ -58,6 +58,7 @@ Keep this file up to date whenever adding or removing support.
 | 50 | Search capability | `~/code/nips/50.md` | `src/relay/core/FilterMatcher.ts` | `src/client/Nip50Service.test.ts` |
 | 09 | Event deletion | `~/code/nips/09.md` | `src/relay/core/MessageHandler.ts` | `src/relay/Nip09Deletion.test.ts` |
 | 31 | Unknown kinds (alt tag) | `~/code/nips/31.md` | `src/wrappers/nip31.ts` | `src/wrappers/nip31.test.ts` |
+| 14 | Subject tag | `~/code/nips/14.md` | `src/wrappers/nip14.ts` | `src/wrappers/nip14.test.ts` |
 | 94 | File metadata | `~/code/nips/94.md` | `src/core/Nip94.ts`, `src/wrappers/nip94.ts` | `src/core/Nip94.test.ts` |
 | 98 | HTTP auth | `~/code/nips/98.md` | `src/wrappers/nip98.ts` | `src/core/Nip98.test.ts` |
 | 99 | Classified listings | `~/code/nips/99.md` | `src/wrappers/nip99.ts` | `src/core/Nip99.test.ts` |

--- a/src/wrappers/nip14.test.ts
+++ b/src/wrappers/nip14.test.ts
@@ -1,0 +1,35 @@
+import { test, expect, describe } from "bun:test"
+import { withSubject, getSubject, replySubject } from "./nip14.js"
+
+describe("NIP-14 subject tag helpers", () => {
+  test("withSubject sets/replaces subject", () => {
+    const tags: string[][] = [["t", "yak"]]
+    const t1 = withSubject(tags as any, "Yak Talk")
+    expect(t1.find((t) => t[0] === "subject")?.[1]).toBe("Yak Talk")
+    const t2 = withSubject(t1 as any, "Yak Talk Updated")
+    const subs = t2.filter((t) => t[0] === "subject")
+    expect(subs.length).toBe(1)
+    expect(subs[0]?.[1]).toBe("Yak Talk Updated")
+  })
+
+  test("getSubject returns value or null", () => {
+    const event = {
+      id: "e".repeat(64),
+      pubkey: "a".repeat(64),
+      created_at: 1,
+      kind: 1,
+      content: "hi",
+      tags: [["subject", "Topic"], ["t", "yak"]],
+      sig: "f".repeat(128),
+    } as any
+    expect(getSubject(event)).toBe("Topic")
+    expect(getSubject({ ...event, tags: [["t", "yak"]] } as any)).toBeNull()
+  })
+
+  test("replySubject adorns with Re: ", () => {
+    expect(replySubject("Topic")).toBe("Re: Topic")
+    expect(replySubject("Re: Topic")).toBe("Re: Topic")
+    expect(replySubject(null)).toBeNull()
+  })
+})
+

--- a/src/wrappers/nip14.ts
+++ b/src/wrappers/nip14.ts
@@ -1,0 +1,24 @@
+/**
+ * NIP-14: Subject tag in Text events (kind 1)
+ */
+import type { Tag, NostrEvent } from "../core/Schema.js"
+
+/** Add or replace the `subject` tag */
+export function withSubject(tags: Tag[], subject: string): Tag[] {
+  const filtered = tags.filter((t) => t[0] !== "subject")
+  return [...filtered, ["subject", subject] as unknown as Tag]
+}
+
+/** Get the `subject` tag value */
+export function getSubject(event: NostrEvent): string | null {
+  const t = event.tags.find((x) => x[0] === "subject")
+  return t?.[1] ?? null
+}
+
+/** For replies, replicate subject with optional adornment (e.g., prefix 'Re: ') */
+export function replySubject(originalSubject: string | null, adornment = "Re: "): string | null {
+  if (!originalSubject || originalSubject.length === 0) return null
+  if (originalSubject.startsWith(adornment)) return originalSubject
+  return `${adornment}${originalSubject}`
+}
+


### PR DESCRIPTION
Implements NIP-14 (Subject tag):\n\n- Adds wrappers/nip14.ts with withSubject/getSubject/replySubject\n- Tests in wrappers/nip14.test.ts\n- Updates SUPPORTED_NIPS.md\n\nVerification\n- bun run verify passes