### PR TITLE
feat(nip-36): content-warning helpers + tests

### DIFF
--- a/docs/SUPPORTED_NIPS.md
+++ b/docs/SUPPORTED_NIPS.md
@@ -59,6 +59,7 @@ Keep this file up to date whenever adding or removing support.
 | 09 | Event deletion | `~/code/nips/09.md` | `src/relay/core/MessageHandler.ts` | `src/relay/Nip09Deletion.test.ts` |
 | 31 | Unknown kinds (alt tag) | `~/code/nips/31.md` | `src/wrappers/nip31.ts` | `src/wrappers/nip31.test.ts` |
 | 14 | Subject tag | `~/code/nips/14.md` | `src/wrappers/nip14.ts` | `src/wrappers/nip14.test.ts` |
+| 36 | Sensitive content (content-warning) | `~/code/nips/36.md` | `src/wrappers/nip36.ts` | `src/wrappers/nip36.test.ts` |
 | 94 | File metadata | `~/code/nips/94.md` | `src/core/Nip94.ts`, `src/wrappers/nip94.ts` | `src/core/Nip94.test.ts` |
 | 98 | HTTP auth | `~/code/nips/98.md` | `src/wrappers/nip98.ts` | `src/core/Nip98.test.ts` |
 | 99 | Classified listings | `~/code/nips/99.md` | `src/wrappers/nip99.ts` | `src/core/Nip99.test.ts` |

--- a/src/wrappers/nip36.test.ts
+++ b/src/wrappers/nip36.test.ts
@@ -1,0 +1,40 @@
+import { test, expect, describe } from "bun:test"
+import { withContentWarning, getContentWarningReason, withContentWarningLabels } from "./nip36.js"
+
+describe("NIP-36 content warning helpers", () => {
+  test("withContentWarning adds/replaces content-warning tag", () => {
+    const tags: string[][] = [["t", "yak"]]
+    const t1 = withContentWarning(tags as any)
+    expect(t1.find((t) => t[0] === "content-warning")?.length).toBe(1)
+    const t2 = withContentWarning(t1 as any, "nsfw")
+    const cw = t2.find((t) => t[0] === "content-warning")
+    expect(cw?.[1]).toBe("nsfw")
+  })
+
+  test("getContentWarningReason handles none/empty/reason", () => {
+    const base = {
+      id: "e".repeat(64),
+      pubkey: "a".repeat(64),
+      created_at: 1,
+      kind: 1,
+      content: "",
+      sig: "f".repeat(128),
+    } as any
+    const evNone = { ...base, tags: [["t", "yak"]] }
+    expect(getContentWarningReason(evNone)).toBeNull()
+    const evEmpty = { ...base, tags: [["content-warning"]] }
+    expect(getContentWarningReason(evEmpty)).toBe("")
+    const evReason = { ...base, tags: [["content-warning", "nsfw"]] }
+    expect(getContentWarningReason(evReason)).toBe("nsfw")
+  })
+
+  test("withContentWarningLabels adds L and l tags for content-warning namespace", () => {
+    const tags: string[][] = []
+    const t1 = withContentWarningLabels(tags as any, ["NS-nud", "NS-viol"])
+    expect(t1.find((t) => t[0] === "L" && t[1] === "content-warning")).toBeTruthy()
+    const ls = t1.filter((t) => t[0] === "l")
+    expect(ls.map((t) => t[1])).toEqual(["NS-nud", "NS-viol"])
+    expect(ls.every((t) => t[2] === "content-warning")).toBe(true)
+  })
+})
+

--- a/src/wrappers/nip36.ts
+++ b/src/wrappers/nip36.ts
@@ -1,0 +1,33 @@
+/**
+ * NIP-36: Sensitive Content / Content Warning
+ */
+import type { Tag, NostrEvent } from "../core/Schema.js"
+
+/** Add or replace the content-warning tag, with optional reason */
+export function withContentWarning(tags: Tag[], reason?: string): Tag[] {
+  const filtered = tags.filter((t) => t[0] !== "content-warning")
+  const cw: Tag = (["content-warning", ...(reason ? [reason] : [])] as unknown) as Tag
+  return [...filtered, cw]
+}
+
+/** Get content-warning reason, or empty string if present but no reason, or null if not present */
+export function getContentWarningReason(event: NostrEvent): string | null {
+  const t = event.tags.find((x) => x[0] === "content-warning")
+  if (!t) return null
+  return t[1] ?? ""
+}
+
+/**
+ * Optional: include labeling via NIP-32 (L/l) for content-warning namespaces
+ * Returns tags with appended L/l tags where appropriate.
+ */
+export function withContentWarningLabels(tags: Tag[], labels: readonly string[] = []): Tag[] {
+  const hasL = tags.some((t) => t[0] === "L" && t[1] === "content-warning")
+  const out = [...tags]
+  if (!hasL) out.push((["L", "content-warning"] as unknown) as Tag)
+  for (const label of labels) {
+    out.push((["l", label, "content-warning"] as unknown) as Tag)
+  }
+  return out
+}
+


### PR DESCRIPTION
Implements NIP-36 (Sensitive Content / Content Warning):\n\n- Adds wrappers/nip36.ts (withContentWarning/getContentWarningReason/withContentWarningLabels)\n- Tests in wrappers/nip36.test.ts\n- Updates SUPPORTED_NIPS.md\n\nVerification\n- bun run verify passes