### PR TITLE
feat: NIP-26 Delegated Event Signing (wrapper + tests)

### DIFF
--- a/docs/SUPPORTED_NIPS.md
+++ b/docs/SUPPORTED_NIPS.md
@@ -66,6 +66,7 @@ Keep this file up to date whenever adding or removing support.
 | 94 | File metadata | `~/code/nips/94.md` | `src/core/Nip94.ts`, `src/wrappers/nip94.ts` | `src/core/Nip94.test.ts` |
 | 98 | HTTP auth | `~/code/nips/98.md` | `src/wrappers/nip98.ts` | `src/core/Nip98.test.ts` |
 | 99 | Classified listings | `~/code/nips/99.md` | `src/wrappers/nip99.ts` | `src/core/Nip99.test.ts` |
+| 26 | Delegated event signing | `~/code/nips/26.md` | `src/wrappers/nip26.ts` | `src/wrappers/nip26.test.ts` |
 
 Notes
 - Registry modules live under `src/relay/core/nip/modules/**`. Default relay modules: NIP-01, NIP-11, NIP-16/33. Others (e.g., NIP-28, NIP-57, NIP-42) are available but may not be in `DefaultModules`.

--- a/docs/UNSUPPORTED_NIPS.md
+++ b/docs/UNSUPPORTED_NIPS.md
@@ -12,7 +12,6 @@ Source of truth for supported NIPs: `docs/SUPPORTED_NIPS.md`.
 - 20 — `~/code/nips/20.md`
 - 22 — `~/code/nips/22.md`
 - 24 — `~/code/nips/24.md`
-- 26 — `~/code/nips/26.md`
 - 35 — `~/code/nips/35.md`
 - 37 — `~/code/nips/37.md`
 - 38 — `~/code/nips/38.md`

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "./nip19": "./src/wrappers/nip19.ts",
     "./nip21": "./src/wrappers/nip21.ts",
     "./nip25": "./src/wrappers/nip25.ts",
+    "./nip26": "./src/wrappers/nip26.ts",
     "./nip27": "./src/wrappers/nip27.ts",
     "./nip28": "./src/wrappers/nip28.ts",
     "./nip30": "./src/wrappers/nip30.ts",

--- a/src/wrappers/nip26.test.ts
+++ b/src/wrappers/nip26.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Tests for NIP-26 Delegated Event Signing
+ */
+import { describe, test, expect } from "bun:test"
+import { generateSecretKey, getPublicKey, finalizeEvent, verifyEvent } from "./pure.js"
+import {
+  createDelegationTag,
+  verifyDelegationTag,
+  finalizeDelegatedEvent,
+  verifyDelegatedEvent,
+  type DelegationTag,
+} from "./nip26.js"
+
+describe("NIP-26 Delegation", () => {
+  test("create and verify delegation tag", () => {
+    const delegatorSk = generateSecretKey()
+    const delegatorPk = getPublicKey(delegatorSk)
+    const delegateSk = generateSecretKey()
+    const delegatePk = getPublicKey(delegateSk)
+
+    const conditions = "kind=1&created_at<4102444800" // year 2100
+
+    const tag = createDelegationTag(delegatorSk, delegatePk, conditions)
+    expect(tag[0]).toBe("delegation")
+    expect(tag[1]).toBe(delegatorPk)
+    expect(tag[2]).toBe(conditions)
+    expect(tag[3].length).toBe(128)
+
+    expect(verifyDelegationTag(tag, delegatePk)).toBe(true)
+
+    // tamper conditions should fail
+    const bad: DelegationTag = [tag[0], tag[1], "kind=1", tag[3]]
+    expect(verifyDelegationTag(bad, delegatePk)).toBe(false)
+  })
+
+  test("delegated event signs with delegate and includes delegation tag", () => {
+    const delegatorSk = generateSecretKey()
+    const delegateSk = generateSecretKey()
+    const delegatePk = getPublicKey(delegateSk)
+    const conditions = "kind=1&created_at<4102444800"
+
+    const tag = createDelegationTag(delegatorSk, delegatePk, conditions)
+
+    const template = {
+      kind: 1,
+      content: "hello from delegate",
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [],
+    }
+
+    const delegated = finalizeDelegatedEvent(template, delegateSk, tag)
+    expect(delegated.pubkey).toBe(delegatePk)
+    expect(verifyDelegatedEvent(delegated)).toBe(true)
+
+    // regular event verification should succeed too
+    expect(verifyEvent(delegated)).toBe(true)
+  })
+
+  test("verifyDelegatedEvent fails when delegation tag is missing or invalid", () => {
+    const delegatorSk = generateSecretKey()
+    const delegateSk = generateSecretKey()
+    const delegatePk = getPublicKey(delegateSk)
+    const conditions = "kind=1"
+    const tag = createDelegationTag(delegatorSk, delegatePk, conditions)
+
+    const template = {
+      kind: 1,
+      content: "no tag",
+      created_at: Math.floor(Date.now() / 1000),
+      tags: [],
+    }
+    const signed = finalizeEvent(template, delegateSk)
+
+    // Missing delegation tag
+    expect(verifyDelegatedEvent(signed)).toBe(false)
+
+    // Add tag but tamper signature
+    const tamperedTag: DelegationTag = ["delegation", tag[1], tag[2], "f".repeat(128)]
+    const delegated = finalizeDelegatedEvent(template, delegateSk, tamperedTag)
+    expect(verifyDelegatedEvent(delegated)).toBe(false)
+  })
+})

--- a/src/wrappers/nip26.ts
+++ b/src/wrappers/nip26.ts
@@ -1,0 +1,102 @@
+/**
+ * NIP-26: Delegated Event Signing
+ *
+ * Helpers to create and verify delegation tokens and to sign delegated events.
+ *
+ * Spec: ~/code/nips/26.md
+ */
+import { schnorr } from "@noble/curves/secp256k1"
+import { sha256 } from "@noble/hashes/sha256"
+import { bytesToHex } from "@noble/hashes/utils"
+import type { Event, EventTemplate } from "./pure.js"
+import { finalizeEvent, getPublicKey, verifyEvent } from "./pure.js"
+
+/**
+ * A delegation tag as used in NIP-26
+ * ["delegation", delegatorPubkey, conditions, signature]
+ */
+export type DelegationTag = ["delegation", string, string, string]
+
+/**
+ * Build the NIP-26 signing payload for a given delegate and conditions.
+ *
+ * message = `nostr:delegation:${delegatePubkey}:${conditions}`
+ */
+export function buildDelegationMessage(delegatePubkey: string, conditions: string): Uint8Array {
+  const msg = `nostr:delegation:${delegatePubkey}:${conditions}`
+  return new TextEncoder().encode(msg)
+}
+
+/**
+ * Create a delegation tag signed by the delegator.
+ *
+ * @param delegatorSecretKey - delegator secret key (Uint8Array)
+ * @param delegatePubkey - hex public key of the delegate
+ * @param conditions - authorization string (e.g., "kind=1&created_at<1700000000")
+ */
+export function createDelegationTag(
+  delegatorSecretKey: Uint8Array,
+  delegatePubkey: string,
+  conditions: string
+): DelegationTag {
+  const delegatorPubkey = getPublicKey(delegatorSecretKey)
+  const msg = buildDelegationMessage(delegatePubkey, conditions)
+  const digest = sha256(msg)
+  const sig = schnorr.sign(bytesToHex(digest), delegatorSecretKey)
+  return ["delegation", delegatorPubkey, conditions, bytesToHex(sig)]
+}
+
+/**
+ * Verify the delegation tag against the given delegate public key.
+ *
+ * @param tag - delegation tag
+ * @param delegatePubkey - expected delegate pubkey (hex)
+ * @returns true if signature is valid for message and delegator pubkey
+ */
+export function verifyDelegationTag(tag: DelegationTag, delegatePubkey: string): boolean {
+  const [_t, delegatorPubkey, conditions, sig] = tag
+  // Build message hash
+  const msg = buildDelegationMessage(delegatePubkey, conditions)
+  const digest = sha256(msg)
+  try {
+    return schnorr.verify(sig, bytesToHex(digest), delegatorPubkey)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Attach a delegation tag to an event template's tags array.
+ */
+export function withDelegationTag<T extends EventTemplate>(tmpl: T, tag: DelegationTag): T {
+  const tags = Array.isArray(tmpl.tags) ? tmpl.tags.slice() : []
+  tags.push(tag)
+  return { ...tmpl, tags } as T
+}
+
+/**
+ * Sign a delegated event: attaches the provided delegation tag and signs the event with the delegate secret key.
+ *
+ * Note: This function does not validate the tag; callers can use `verifyDelegationTag` prior to publishing.
+ */
+export function finalizeDelegatedEvent(
+  template: EventTemplate,
+  delegateSecretKey: Uint8Array,
+  delegationTag: DelegationTag
+): Event {
+  const withTag = withDelegationTag(template, delegationTag)
+  return finalizeEvent(withTag, delegateSecretKey)
+}
+
+/**
+ * Verify a delegated event:
+ * - verifies the event signature (delegate-signed)
+ * - verifies the delegation tag signature against the event.pubkey
+ */
+export function verifyDelegatedEvent(event: Event): boolean {
+  if (!verifyEvent(event)) return false
+  const tag = event.tags.find((t) => t[0] === "delegation") as DelegationTag | undefined
+  if (!tag) return false
+  // tag format: ["delegation", delegatorPubkey, conditions, signature]
+  return verifyDelegationTag(tag, event.pubkey)
+}


### PR DESCRIPTION
- Add wrappers/nip26.ts: create/verify delegation tag, finalize delegated events, verify delegated events
- Add tests: src/wrappers/nip26.test.ts covering happy path and negative cases
- Export nip26 in package.json
- Update docs/SUPPORTED_NIPS.md with NIP-26 row; remove #26 from docs/UNSUPPORTED_NIPS.md

All changes pass `bun run verify` (typecheck + tests).