### PR TITLE
feat: NIP-56 Reporting (wrapper + tests)

### DIFF
--- a/docs/SUPPORTED_NIPS.md
+++ b/docs/SUPPORTED_NIPS.md
@@ -67,6 +67,7 @@ Keep this file up to date whenever adding or removing support.
 | 98 | HTTP auth | `~/code/nips/98.md` | `src/wrappers/nip98.ts` | `src/core/Nip98.test.ts` |
 | 99 | Classified listings | `~/code/nips/99.md` | `src/wrappers/nip99.ts` | `src/core/Nip99.test.ts` |
 | 26 | Delegated event signing | `~/code/nips/26.md` | `src/wrappers/nip26.ts` | `src/wrappers/nip26.test.ts` |
+| 56 | Reporting | `~/code/nips/56.md` | `src/wrappers/nip56.ts` | `src/wrappers/nip56.test.ts` |
 
 Notes
 - Registry modules live under `src/relay/core/nip/modules/**`. Default relay modules: NIP-01, NIP-11, NIP-16/33. Others (e.g., NIP-28, NIP-57, NIP-42) are available but may not be in `DefaultModules`.

--- a/docs/UNSUPPORTED_NIPS.md
+++ b/docs/UNSUPPORTED_NIPS.md
@@ -17,7 +17,6 @@ Source of truth for supported NIPs: `docs/SUPPORTED_NIPS.md`.
 - 38 — `~/code/nips/38.md`
 - 43 — `~/code/nips/43.md`
 - 55 — `~/code/nips/55.md`
-- 56 — `~/code/nips/56.md`
 - 60 — `~/code/nips/60.md`
 - 61 — `~/code/nips/61.md`
 - 64 — `~/code/nips/64.md`

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "./nip21": "./src/wrappers/nip21.ts",
     "./nip25": "./src/wrappers/nip25.ts",
     "./nip26": "./src/wrappers/nip26.ts",
+    "./nip56": "./src/wrappers/nip56.ts",
     "./nip27": "./src/wrappers/nip27.ts",
     "./nip28": "./src/wrappers/nip28.ts",
     "./nip30": "./src/wrappers/nip30.ts",

--- a/src/wrappers/nip56.test.ts
+++ b/src/wrappers/nip56.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Tests for NIP-56 Reporting (kind 1984)
+ */
+import { describe, test, expect } from "bun:test"
+import { generateSecretKey, getPublicKey, verifyEvent } from "./pure.js"
+import {
+  buildProfileReportTemplate,
+  buildNoteReportTemplate,
+  buildBlobReportTemplate,
+  signReport,
+} from "./nip56.js"
+
+describe("NIP-56 Reporting", () => {
+  test("profile report builds correct tags and verifies", () => {
+    const sk = generateSecretKey()
+    const target = getPublicKey(generateSecretKey())
+    const tmpl = buildProfileReportTemplate({ kind: 1984, pubkey: target, report: "nudity" })
+    const evt = signReport(tmpl, sk)
+    expect(evt.kind).toBe(1984)
+    const p = evt.tags.find((t) => t[0] === "p")
+    expect(p?.[1]).toBe(target)
+    expect(p?.[2]).toBe("nudity")
+    expect(verifyEvent(evt)).toBe(true)
+  })
+
+  test("note report includes e + optional p tag", () => {
+    const sk = generateSecretKey()
+    const eventId = "e".repeat(64)
+    const target = getPublicKey(generateSecretKey())
+    const tmpl = buildNoteReportTemplate({ kind: 1984, eventId, pubkey: target, report: "illegal" })
+    const evt = signReport(tmpl, sk)
+    const e = evt.tags.find((t) => t[0] === "e")
+    const p = evt.tags.find((t) => t[0] === "p")
+    expect(e?.[1]).toBe(eventId)
+    expect(e?.[2]).toBe("illegal")
+    expect(p?.[1]).toBe(target)
+    expect(verifyEvent(evt)).toBe(true)
+  })
+
+  test("blob report includes x + e + server tags as applicable", () => {
+    const sk = generateSecretKey()
+    const blobHash = "a".repeat(64)
+    const eventId = "b".repeat(64)
+    const server = "https://media.example/file.jpg"
+    const tmpl = buildBlobReportTemplate({ kind: 1984, blobHash, eventId, server, report: "malware" })
+    const evt = signReport(tmpl, sk)
+    const x = evt.tags.find((t) => t[0] === "x")
+    const e = evt.tags.find((t) => t[0] === "e")
+    const s = evt.tags.find((t) => t[0] === "server")
+    expect(x?.[1]).toBe(blobHash)
+    expect(x?.[2]).toBe("malware")
+    expect(e?.[1]).toBe(eventId)
+    expect(e?.[2]).toBe("malware")
+    expect(s?.[1]).toBe(server)
+    expect(verifyEvent(evt)).toBe(true)
+  })
+})

--- a/src/wrappers/nip56.ts
+++ b/src/wrappers/nip56.ts
@@ -1,0 +1,85 @@
+/**
+ * NIP-56: Reporting (kind 1984)
+ *
+ * Helpers to build and sign reports for users, notes, and blobs.
+ * Spec: ~/code/nips/56.md
+ */
+import type { Event, EventTemplate } from "./pure.js"
+import { finalizeEvent } from "./pure.js"
+
+export type ReportType =
+  | "nudity"
+  | "malware"
+  | "profanity"
+  | "illegal"
+  | "spam"
+  | "impersonation"
+  | "other"
+
+export interface BaseReportTemplate {
+  created_at?: number
+  content?: string
+  extraTags?: string[][]
+}
+
+export interface ProfileReport extends BaseReportTemplate {
+  kind: 1984
+  pubkey: string
+  report: ReportType
+}
+
+export interface NoteReport extends BaseReportTemplate {
+  kind: 1984
+  eventId: string
+  pubkey?: string
+  report: ReportType
+}
+
+export interface BlobReport extends BaseReportTemplate {
+  kind: 1984
+  blobHash: string
+  eventId?: string
+  server?: string
+  report: ReportType
+}
+
+export function buildProfileReportTemplate(input: ProfileReport): EventTemplate {
+  const tags: string[][] = [["p", input.pubkey, input.report]]
+  if (input.extraTags) tags.push(...input.extraTags)
+  return {
+    kind: 1984,
+    created_at: input.created_at ?? Math.floor(Date.now() / 1000),
+    content: input.content ?? "",
+    tags,
+  }
+}
+
+export function buildNoteReportTemplate(input: NoteReport): EventTemplate {
+  const tags: string[][] = [["e", input.eventId, input.report]]
+  if (input.pubkey) tags.push(["p", input.pubkey])
+  if (input.extraTags) tags.push(...input.extraTags)
+  return {
+    kind: 1984,
+    created_at: input.created_at ?? Math.floor(Date.now() / 1000),
+    content: input.content ?? "",
+    tags,
+  }
+}
+
+export function buildBlobReportTemplate(input: BlobReport): EventTemplate {
+  const tags: string[][] = [["x", input.blobHash, input.report]]
+  if (input.eventId) tags.push(["e", input.eventId, input.report])
+  if (input.server) tags.push(["server", input.server])
+  if (input.extraTags) tags.push(...input.extraTags)
+  return {
+    kind: 1984,
+    created_at: input.created_at ?? Math.floor(Date.now() / 1000),
+    content: input.content ?? "",
+    tags,
+  }
+}
+
+export function signReport(template: EventTemplate, secretKey: Uint8Array): Event {
+  return finalizeEvent(template, secretKey)
+}
+


### PR DESCRIPTION
- Add wrappers/nip56.ts: build/sign report events (profile, note, blob)
- Add tests: src/wrappers/nip56.test.ts
- Export nip56 in package.json
- Update docs/SUPPORTED_NIPS.md and docs/UNSUPPORTED_NIPS.md

All changes pass `bun run verify`.