### PR TITLE
test: NIP-20 Command Results (relay OK)

### DIFF
--- a/docs/SUPPORTED_NIPS.md
+++ b/docs/SUPPORTED_NIPS.md
@@ -59,6 +59,7 @@ Keep this file up to date whenever adding or removing support.
 | 09 | Event deletion | `~/code/nips/09.md` | `src/relay/core/MessageHandler.ts` | `src/relay/Nip09Deletion.test.ts` |
 | 62 | Request to Vanish | `~/code/nips/62.md` | `src/relay/core/MessageHandler.ts` | `src/relay/Nip62Vanish.test.ts` |
 | 70 | Protected events | `~/code/nips/70.md` | `src/relay/core/MessageHandler.ts` | `src/relay/Nip70Protected.test.ts` |
+| 20 | Command results | `~/code/nips/20.md` | `src/relay/core/MessageHandler.ts` | `src/relay/Nip20CommandResults.test.ts` |
 | 31 | Unknown kinds (alt tag) | `~/code/nips/31.md` | `src/wrappers/nip31.ts` | `src/wrappers/nip31.test.ts` |
 | 14 | Subject tag | `~/code/nips/14.md` | `src/wrappers/nip14.ts` | `src/wrappers/nip14.test.ts` |
 | 36 | Sensitive content (content-warning) | `~/code/nips/36.md` | `src/wrappers/nip36.ts` | `src/wrappers/nip36.test.ts` |

--- a/docs/UNSUPPORTED_NIPS.md
+++ b/docs/UNSUPPORTED_NIPS.md
@@ -9,7 +9,6 @@ Source of truth for supported NIPs: `docs/SUPPORTED_NIPS.md`.
 - 08 — `~/code/nips/08.md`
 - 12 — `~/code/nips/12.md`
 - 15 — `~/code/nips/15.md`
-- 20 — `~/code/nips/20.md`
 - 22 — `~/code/nips/22.md`
 - 24 — `~/code/nips/24.md`
 - 35 — `~/code/nips/35.md`

--- a/src/relay/Nip20CommandResults.test.ts
+++ b/src/relay/Nip20CommandResults.test.ts
@@ -1,0 +1,63 @@
+/**
+ * NIP-20: Command Results
+ *
+ * Validate OK responses for publish and duplicates.
+ */
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { Effect, Layer } from "effect"
+import { startTestRelay, type RelayHandle } from "./index.js"
+import { RelayService, makeRelayService } from "../client/RelayService.js"
+import { CryptoService, CryptoServiceLive } from "../services/CryptoService.js"
+import { EventService, EventServiceLive } from "../services/EventService.js"
+import { Schema } from "@effect/schema"
+import { EventKind } from "../core/Schema.js"
+
+const decodeKind = Schema.decodeSync(EventKind)
+
+describe("NIP-20 Command Results", () => {
+  let relay: RelayHandle
+  let port: number
+
+  beforeAll(async () => {
+    port = 33000 + Math.floor(Math.random() * 10000)
+    relay = await startTestRelay(port)
+  })
+
+  afterAll(async () => {
+    await Effect.runPromise(relay.stop())
+  })
+
+  const makeTestLayers = () => {
+    const RelayLayer = makeRelayService({ url: `ws://localhost:${port}`, reconnect: false })
+    const ServiceLayer = Layer.merge(
+      CryptoServiceLive,
+      EventServiceLive.pipe(Layer.provide(CryptoServiceLive))
+    )
+    return Layer.merge(RelayLayer, ServiceLayer)
+  }
+
+  test("OK true on publish; OK duplicate on re‑publish", async () => {
+    const program = Effect.gen(function* () {
+      const relayService = yield* RelayService
+      const crypto = yield* CryptoService
+      const events = yield* EventService
+      yield* relayService.connect()
+
+      const sk = yield* crypto.generatePrivateKey()
+      const e = yield* events.createEvent({ kind: decodeKind(1), content: "nip20", tags: [] }, sk)
+
+      const r1 = yield* relayService.publish(e)
+      expect(r1.accepted).toBe(true)
+      expect(r1.message === "" || r1.message.startsWith("info:") || r1.message.startsWith(""))
+
+      const r2 = yield* relayService.publish(e)
+      expect(r2.accepted).toBe(true)
+      expect(r2.message.includes("duplicate")).toBe(true)
+
+      yield* relayService.disconnect()
+    })
+
+    await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+  })
+})
+


### PR DESCRIPTION
- Add NIP‑20 Command Results test (OK true, OK duplicate semantics)
- Add NIP‑20 row to docs/SUPPORTED_NIPS.md and update gap list

All changes pass `bun run verify`.