### PR TITLE
feat: NIP-43 Relay Access (wrappers + tests)

### DIFF
--- a/docs/SUPPORTED_NIPS.md
+++ b/docs/SUPPORTED_NIPS.md
@@ -69,6 +69,7 @@ Keep this file up to date whenever adding or removing support.
 | 99 | Classified listings | `~/code/nips/99.md` | `src/wrappers/nip99.ts` | `src/core/Nip99.test.ts` |
 | 26 | Delegated event signing | `~/code/nips/26.md` | `src/wrappers/nip26.ts` | `src/wrappers/nip26.test.ts` |
 | 56 | Reporting | `~/code/nips/56.md` | `src/wrappers/nip56.ts` | `src/wrappers/nip56.test.ts` |
+| 43 | Relay access metadata/requests | `~/code/nips/43.md` | `src/wrappers/nip43.ts` | `src/wrappers/nip43.test.ts` |
 
 Notes
 - Registry modules live under `src/relay/core/nip/modules/**`. Default relay modules: NIP-01, NIP-11, NIP-16/33. Others (e.g., NIP-28, NIP-57, NIP-42) are available but may not be in `DefaultModules`.

--- a/docs/UNSUPPORTED_NIPS.md
+++ b/docs/UNSUPPORTED_NIPS.md
@@ -14,7 +14,6 @@ Source of truth for supported NIPs: `docs/SUPPORTED_NIPS.md`.
 - 35 — `~/code/nips/35.md`
 - 37 — `~/code/nips/37.md`
 - 38 — `~/code/nips/38.md`
-- 43 — `~/code/nips/43.md`
 - 55 — `~/code/nips/55.md`
 - 60 — `~/code/nips/60.md`
 - 61 — `~/code/nips/61.md`

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "./nip21": "./src/wrappers/nip21.ts",
     "./nip25": "./src/wrappers/nip25.ts",
     "./nip26": "./src/wrappers/nip26.ts",
+    "./nip43": "./src/wrappers/nip43.ts",
     "./nip56": "./src/wrappers/nip56.ts",
     "./nip27": "./src/wrappers/nip27.ts",
     "./nip28": "./src/wrappers/nip28.ts",

--- a/src/wrappers/nip43.test.ts
+++ b/src/wrappers/nip43.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Tests for NIP-43 Relay Access Metadata and Requests
+ */
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { Effect, Layer } from "effect"
+import { startTestRelay, type RelayHandle } from "../relay/index.js"
+import { RelayService, makeRelayService } from "../client/RelayService.js"
+import { CryptoService, CryptoServiceLive } from "../services/CryptoService.js"
+import { EventService, EventServiceLive } from "../services/EventService.js"
+import { buildMembershipList, buildAddMember, buildRemoveMember, buildJoinRequest, buildLeaveRequest, MembershipListKind, AddMemberKind, RemoveMemberKind, JoinRequestKind, LeaveRequestKind } from "./nip43.js"
+import { Schema } from "@effect/schema"
+import { EventKind, Tag } from "../core/Schema.js"
+
+describe("NIP-43 Relay Access", () => {
+  let relay: RelayHandle
+  let port: number
+
+  beforeAll(async () => {
+    port = 34000 + Math.floor(Math.random() * 10000)
+    relay = await startTestRelay(port)
+  })
+
+  afterAll(async () => {
+    await Effect.runPromise(relay.stop())
+  })
+
+  const makeTestLayers = () => {
+    const RelayLayer = makeRelayService({ url: `ws://localhost:${port}`, reconnect: false })
+    const ServiceLayer = Layer.merge(
+      CryptoServiceLive,
+      EventServiceLive.pipe(Layer.provide(CryptoServiceLive))
+    )
+    return Layer.merge(RelayLayer, ServiceLayer)
+  }
+
+  test("relay membership/admin events verify and publish", async () => {
+    const program = Effect.gen(function* () {
+      const relayService = yield* RelayService
+      const crypto = yield* CryptoService
+      yield* relayService.connect()
+
+      const relaySk = yield* crypto.generatePrivateKey()
+      const events = yield* EventService
+      const member1 = yield* crypto.getPublicKey(yield* crypto.generatePrivateKey())
+      const member2 = yield* crypto.getPublicKey(yield* crypto.generatePrivateKey())
+
+      // membership list
+      const decodeKind = Schema.decodeSync(EventKind)
+      const decodeTag = Schema.decodeSync(Tag)
+      const K_MEMBERS = decodeKind(MembershipListKind as any)
+      const K_ADD = decodeKind(AddMemberKind as any)
+      const K_REM = decodeKind(RemoveMemberKind as any)
+      const mlTmpl = buildMembershipList({ members: [member1, member2] })
+      const ml = yield* events.createEvent({ kind: K_MEMBERS as any, content: mlTmpl.content, tags: mlTmpl.tags.map((t) => decodeTag(t)) }, relaySk)
+      expect(ml.kind).toBe(K_MEMBERS)
+      const rml = yield* relayService.publish(ml)
+      expect(rml.accepted).toBe(false)
+      expect(rml.message.includes("auth-required")).toBe(true)
+
+      // add member
+      const addTmpl = buildAddMember({ pubkey: member1, content: "welcome" })
+      const add = yield* events.createEvent({ kind: K_ADD as any, content: addTmpl.content, tags: addTmpl.tags.map((t) => decodeTag(t)) }, relaySk)
+      expect(add.kind).toBe(K_ADD)
+      const ra = yield* relayService.publish(add)
+      expect(ra.accepted).toBe(false)
+      expect(ra.message.includes("auth-required")).toBe(true)
+
+      // remove member
+      const remTmpl = buildRemoveMember({ pubkey: member2 })
+      const rem = yield* events.createEvent({ kind: K_REM as any, content: remTmpl.content, tags: remTmpl.tags.map((t) => decodeTag(t)) }, relaySk)
+      expect(rem.kind).toBe(K_REM)
+      const rr = yield* relayService.publish(rem)
+      expect(rr.accepted).toBe(false)
+      expect(rr.message.includes("auth-required")).toBe(true)
+
+      yield* relayService.disconnect()
+    })
+
+    await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+  })
+
+  test("client join/leave requests publish and return OK", async () => {
+    const program = Effect.gen(function* () {
+      const relayService = yield* RelayService
+      const crypto = yield* CryptoService
+      yield* relayService.connect()
+
+      const userSk = yield* crypto.generatePrivateKey()
+      const events = yield* EventService
+
+      const decodeKind = Schema.decodeSync(EventKind)
+      const decodeTag = Schema.decodeSync(Tag)
+      const K_JOIN = decodeKind(JoinRequestKind as any)
+      const K_LEAVE = decodeKind(LeaveRequestKind as any)
+      const joinTmpl = buildJoinRequest({ claim: "INVITE-XYZ" })
+      const join = yield* events.createEvent({ kind: K_JOIN as any, content: joinTmpl.content, tags: joinTmpl.tags.map((t) => decodeTag(t)) }, userSk)
+      expect(join.kind).toBe(K_JOIN)
+      const r1 = yield* relayService.publish(join)
+      expect(r1.accepted).toBe(false)
+      expect(r1.message.includes("auth-required")).toBe(true)
+
+      const leaveTmpl = buildLeaveRequest({})
+      const leave = yield* events.createEvent({ kind: K_LEAVE as any, content: leaveTmpl.content, tags: leaveTmpl.tags.map((t) => decodeTag(t)) }, userSk)
+      expect(leave.kind).toBe(K_LEAVE)
+      const r2 = yield* relayService.publish(leave)
+      expect(r2.accepted).toBe(false)
+      expect(r2.message.includes("auth-required")).toBe(true)
+
+      yield* relayService.disconnect()
+    })
+
+    await Effect.runPromise(program.pipe(Effect.provide(makeTestLayers())))
+  })
+})

--- a/src/wrappers/nip43.ts
+++ b/src/wrappers/nip43.ts
@@ -1,0 +1,111 @@
+/**
+ * NIP-43: Relay Access Metadata and Requests
+ *
+ * Spec: ~/code/nips/43.md
+ *
+ * Helpers for membership list, add/remove member events (relay-signed),
+ * and client-side join/leave requests.
+ */
+import type { Event, EventTemplate } from "./pure.js"
+import { finalizeEvent } from "./pure.js"
+
+// Kinds from NIP-43
+export const MembershipListKind = 13534
+export const AddMemberKind = 8000
+export const RemoveMemberKind = 8001
+export const JoinRequestKind = 28934
+export const InviteRequestKind = 28935
+export const LeaveRequestKind = 28936
+
+// -----------------------------------------------------------------------------
+// Relay-signed events
+// -----------------------------------------------------------------------------
+
+export interface MembershipListTemplate {
+  readonly members: readonly string[]
+  readonly content?: string
+  readonly created_at?: number
+}
+
+export function buildMembershipList({ members, content, created_at }: MembershipListTemplate): EventTemplate {
+  const tags: string[][] = [["-"]]
+  for (const m of members) tags.push(["member", m])
+  return {
+    kind: MembershipListKind,
+    content: content ?? "",
+    created_at: created_at ?? Math.floor(Date.now() / 1000),
+    tags,
+  }
+}
+
+export interface AddMemberTemplate {
+  readonly pubkey: string
+  readonly content?: string
+  readonly created_at?: number
+}
+
+export function buildAddMember({ pubkey, content, created_at }: AddMemberTemplate): EventTemplate {
+  return {
+    kind: AddMemberKind,
+    content: content ?? "",
+    created_at: created_at ?? Math.floor(Date.now() / 1000),
+    tags: [["-"], ["p", pubkey]],
+  }
+}
+
+export interface RemoveMemberTemplate {
+  readonly pubkey: string
+  readonly content?: string
+  readonly created_at?: number
+}
+
+export function buildRemoveMember({ pubkey, content, created_at }: RemoveMemberTemplate): EventTemplate {
+  return {
+    kind: RemoveMemberKind,
+    content: content ?? "",
+    created_at: created_at ?? Math.floor(Date.now() / 1000),
+    tags: [["-"], ["p", pubkey]],
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Client-signed requests
+// -----------------------------------------------------------------------------
+
+export interface JoinRequestTemplate {
+  readonly claim: string
+  readonly content?: string
+  readonly created_at?: number
+}
+
+export function buildJoinRequest({ claim, content, created_at }: JoinRequestTemplate): EventTemplate {
+  return {
+    kind: JoinRequestKind,
+    content: content ?? "",
+    created_at: created_at ?? Math.floor(Date.now() / 1000),
+    tags: [["-"], ["claim", claim]],
+  }
+}
+
+export interface LeaveRequestTemplate {
+  readonly content?: string
+  readonly created_at?: number
+}
+
+export function buildLeaveRequest({ content, created_at }: LeaveRequestTemplate = {}): EventTemplate {
+  return {
+    kind: LeaveRequestKind,
+    content: content ?? "",
+    created_at: created_at ?? Math.floor(Date.now() / 1000),
+    tags: [["-"]],
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Signing
+// -----------------------------------------------------------------------------
+
+export function sign(template: EventTemplate, secretKey: Uint8Array): Event {
+  return finalizeEvent(template, secretKey)
+}
+


### PR DESCRIPTION
- Add wrappers/nip43.ts for membership list, add/remove member, join/leave requests
- Add tests: src/wrappers/nip43.test.ts (publishing requires NIP‑70 AUTH, so asserts default auth‑required rejections)
- Export nip43 in package.json
- Update docs/SUPPORTED_NIPS.md and docs/UNSUPPORTED_NIPS.md

All changes pass `bun run verify`.