### PR TITLE
feat: NIP-72 Moderated Communities (builders + tests)

### DIFF
--- a/docs/SUPPORTED_NIPS.md
+++ b/docs/SUPPORTED_NIPS.md
@@ -71,6 +71,7 @@ Keep this file up to date whenever adding or removing support.
 | 56 | Reporting | `~/code/nips/56.md` | `src/wrappers/nip56.ts` | `src/wrappers/nip56.test.ts` |
 | 43 | Relay access metadata/requests | `~/code/nips/43.md` | `src/wrappers/nip43.ts` | `src/wrappers/nip43.test.ts` |
 | 84 | Highlights | `~/code/nips/84.md` | `src/wrappers/nip84.ts` | `src/wrappers/nip84.test.ts` |
+| 72 | Moderated communities | `~/code/nips/72.md` | `src/wrappers/nip72.ts` | `src/wrappers/nip72.test.ts` |
 
 Notes
 - Registry modules live under `src/relay/core/nip/modules/**`. Default relay modules: NIP-01, NIP-11, NIP-16/33. Others (e.g., NIP-28, NIP-57, NIP-42) are available but may not be in `DefaultModules`.

--- a/docs/UNSUPPORTED_NIPS.md
+++ b/docs/UNSUPPORTED_NIPS.md
@@ -20,7 +20,6 @@ Source of truth for supported NIPs: `docs/SUPPORTED_NIPS.md`.
 - 64 — `~/code/nips/64.md`
 - 68 — `~/code/nips/68.md`
 - 69 — `~/code/nips/69.md`
-- 72 — `~/code/nips/72.md`
 - 73 — `~/code/nips/73.md`
 - 77 — `~/code/nips/77.md`
 - 86 — `~/code/nips/86.md`

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "./nip25": "./src/wrappers/nip25.ts",
     "./nip26": "./src/wrappers/nip26.ts",
     "./nip43": "./src/wrappers/nip43.ts",
+    "./nip72": "./src/wrappers/nip72.ts",
     "./nip84": "./src/wrappers/nip84.ts",
     "./nip56": "./src/wrappers/nip56.ts",
     "./nip27": "./src/wrappers/nip27.ts",

--- a/src/wrappers/nip72.test.ts
+++ b/src/wrappers/nip72.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tests for NIP-72 Moderated Communities
+ */
+import { describe, test, expect } from "bun:test"
+import { generateSecretKey, getPublicKey, verifyEvent } from "./pure.js"
+import {
+  CommunityDefinitionKind,
+  CommunityPostKind,
+  CommunityApprovalKind,
+  signCommunityDefinition,
+  signCommunityPost,
+  signCommunityApproval,
+} from "./nip72.js"
+
+describe("NIP-72 Moderated Communities", () => {
+  test("build and sign community definition with moderators and relays", () => {
+    const ownerSk = generateSecretKey()
+    const mod1 = getPublicKey(generateSecretKey())
+    const mod2 = getPublicKey(generateSecretKey())
+
+    const evt = signCommunityDefinition({
+      d: "my-community",
+      name: "My Community",
+      description: "Welcome!",
+      image: { url: "https://img.example/logo.png", size: "512x512" },
+      moderators: [
+        { pubkey: mod1, relay: "wss://relay.mods" },
+        { pubkey: mod2 },
+      ],
+      relays: [
+        { url: "wss://relay.author", marker: "author" },
+        { url: "wss://relay.requests", marker: "requests" },
+        { url: "wss://relay.approvals", marker: "approvals" },
+      ],
+    }, ownerSk)
+
+    expect(evt.kind).toBe(CommunityDefinitionKind)
+    const dTag = evt.tags.find((t) => t[0] === "d")
+    expect(dTag?.[1]).toBe("my-community")
+    const pModerator = evt.tags.filter((t) => t[0] === "p")
+    expect(pModerator.length).toBe(2)
+    expect(pModerator[0]?.[3]).toBe("moderator")
+    expect(verifyEvent(evt)).toBe(true)
+  })
+
+  test("build and sign top‑level community post tags (A/a, P/p, K/k)", () => {
+    const ownerSk = generateSecretKey()
+    const ownerPk = getPublicKey(ownerSk)
+    const postSk = generateSecretKey()
+    // ensure builder signatures are valid
+    const evt = signCommunityPost({ community: { ownerPubkey: ownerPk, d: "my-comm", relay: "wss://r" }, content: "hello" }, postSk)
+    expect(evt.kind).toBe(CommunityPostKind)
+    const A = evt.tags.find((t) => t[0] === "A")
+    const a = evt.tags.find((t) => t[0] === "a")
+    const P = evt.tags.find((t) => t[0] === "P")
+    const p = evt.tags.find((t) => t[0] === "p")
+    const K = evt.tags.find((t) => t[0] === "K")
+    const k = evt.tags.find((t) => t[0] === "k")
+    expect(A?.[1]).toBe(`${CommunityDefinitionKind}:${ownerPk}:my-comm`)
+    expect(a?.[1]).toBe(`${CommunityDefinitionKind}:${ownerPk}:my-comm`)
+    expect(P?.[1]).toBe(ownerPk)
+    expect(p?.[1]).toBe(ownerPk)
+    expect(K?.[1]).toBe(String(CommunityDefinitionKind))
+    expect(k?.[1]).toBe(String(CommunityDefinitionKind))
+    expect(verifyEvent(evt)).toBe(true)
+  })
+
+  test("build and sign reply post tags (A/P/K + e/p/k)", () => {
+    const ownerSk = generateSecretKey()
+    const ownerPk = getPublicKey(ownerSk)
+    const authorSk = generateSecretKey()
+    // authorPk available if needed
+    const parent = signCommunityPost({ community: { ownerPubkey: ownerPk, d: "my-comm" }, content: "root" }, authorSk)
+
+    const reply = signCommunityPost({
+      community: { ownerPubkey: ownerPk, d: "my-comm" },
+      parentEventId: parent.id,
+      parentAuthorPubkey: parent.pubkey,
+      parentKind: parent.kind,
+      content: "reply",
+    }, authorSk)
+
+    expect(reply.kind).toBe(CommunityPostKind)
+    expect(reply.tags.find((t) => t[0] === "A")?.[1]).toBe(`${CommunityDefinitionKind}:${ownerPk}:my-comm`)
+    expect(reply.tags.find((t) => t[0] === "e")?.[1]).toBe(parent.id)
+    expect(reply.tags.find((t) => t[0] === "p")?.[1]).toBe(parent.pubkey)
+    expect(reply.tags.find((t) => t[0] === "k")?.[1]).toBe(String(parent.kind))
+    expect(verifyEvent(reply)).toBe(true)
+  })
+
+  test("build and sign approval event (kind 4550)", () => {
+    const ownerSk = generateSecretKey()
+    const ownerPk = getPublicKey(ownerSk)
+    const authorSk = generateSecretKey()
+    const authorPk = getPublicKey(authorSk)
+    const post = signCommunityPost({ community: { ownerPubkey: ownerPk, d: "my-comm" }, content: "post" }, authorSk)
+
+    const approval = signCommunityApproval({
+      community: { ownerPubkey: ownerPk, d: "my-comm" },
+      post,
+      postAuthorPubkey: authorPk,
+      postRequestKind: post.kind,
+    }, ownerSk)
+
+    expect(approval.kind).toBe(CommunityApprovalKind)
+    const a = approval.tags.find((t) => t[0] === "a")
+    const e = approval.tags.find((t) => t[0] === "e")
+    const p = approval.tags.find((t) => t[0] === "p")
+    const k = approval.tags.find((t) => t[0] === "k")
+    expect(a?.[1]).toBe(`${CommunityDefinitionKind}:${ownerPk}:my-comm`)
+    expect(e?.[1]).toBe(post.id)
+    expect(p?.[1]).toBe(authorPk)
+    expect(k?.[1]).toBe(String(post.kind))
+    // content should be JSON of the post if not overridden
+    expect(() => JSON.parse(approval.content)).not.toThrow()
+    expect(verifyEvent(approval)).toBe(true)
+  })
+})

--- a/src/wrappers/nip72.ts
+++ b/src/wrappers/nip72.ts
@@ -1,0 +1,172 @@
+/**
+ * NIP-72: Moderated Communities (Reddit Style)
+ *
+ * Spec: ~/code/nips/72.md
+ */
+import type { Event, EventTemplate } from "./pure.js"
+import { finalizeEvent } from "./pure.js"
+
+// Kinds
+export const CommunityDefinitionKind = 34550
+export const CommunityPostKind = 1111 // NIP-22 post kind for communities
+export const CommunityApprovalKind = 4550
+
+// -----------------------------------------------------------------------------
+// Community Definition
+// -----------------------------------------------------------------------------
+
+export interface CommunityModerator {
+  readonly pubkey: string
+  readonly relay?: string
+}
+
+export interface CommunityRelay {
+  readonly url: string
+  readonly marker?: string // "author" | "requests" | "approvals" | etc.
+}
+
+export interface CommunityDefinitionTemplate {
+  readonly d: string
+  readonly name?: string
+  readonly description?: string
+  readonly image?: { url: string; size?: string }
+  readonly moderators?: readonly CommunityModerator[]
+  readonly relays?: readonly CommunityRelay[]
+  readonly content?: string
+  readonly created_at?: number
+  readonly extraTags?: readonly string[][]
+}
+
+export function buildCommunityDefinition(t: CommunityDefinitionTemplate): EventTemplate {
+  const tags: string[][] = [["d", t.d]]
+  if (t.name) tags.push(["name", t.name])
+  if (t.description) tags.push(["description", t.description])
+  if (t.image) tags.push(["image", t.image.url, ...(t.image.size ? [t.image.size] : [])])
+  if (t.moderators) {
+    for (const m of t.moderators) {
+      const tag: string[] = ["p", m.pubkey]
+      if (m.relay) tag.push(m.relay)
+      tag.push("moderator")
+      tags.push(tag)
+    }
+  }
+  if (t.relays) {
+    for (const r of t.relays) {
+      const tag: string[] = ["relay", r.url]
+      if (r.marker) tag.push(r.marker)
+      tags.push(tag)
+    }
+  }
+  if (t.extraTags) tags.push(...t.extraTags.map((x) => x.slice()))
+  return {
+    kind: CommunityDefinitionKind,
+    content: t.content ?? "",
+    created_at: t.created_at ?? Math.floor(Date.now() / 1000),
+    tags,
+  }
+}
+
+export function signCommunityDefinition(t: CommunityDefinitionTemplate, sk: Uint8Array): Event {
+  return finalizeEvent(buildCommunityDefinition(t), sk)
+}
+
+// -----------------------------------------------------------------------------
+// Post to Community (NIP-22 kind 1111)
+// -----------------------------------------------------------------------------
+
+export interface CommunityPointer {
+  readonly ownerPubkey: string // community definition author pubkey
+  readonly d: string
+  readonly relay?: string
+}
+
+export interface CommunityTopPostTemplate {
+  readonly community: CommunityPointer
+  readonly content: string
+  readonly created_at?: number
+}
+
+export function buildTopLevelCommunityPost(t: CommunityTopPostTemplate): EventTemplate {
+  const a = `${CommunityDefinitionKind}:${t.community.ownerPubkey}:${t.community.d}`
+  const tags: string[][] = [
+    ["A", a, ...(t.community.relay ? [t.community.relay] : [])],
+    ["a", a, ...(t.community.relay ? [t.community.relay] : [])],
+    ["P", t.community.ownerPubkey, ...(t.community.relay ? [t.community.relay] : [])],
+    ["p", t.community.ownerPubkey, ...(t.community.relay ? [t.community.relay] : [])],
+    ["K", String(CommunityDefinitionKind)],
+    ["k", String(CommunityDefinitionKind)],
+  ]
+  return {
+    kind: CommunityPostKind,
+    content: t.content,
+    created_at: t.created_at ?? Math.floor(Date.now() / 1000),
+    tags,
+  }
+}
+
+export interface CommunityReplyTemplate {
+  readonly community: CommunityPointer
+  readonly parentEventId: string
+  readonly parentAuthorPubkey: string
+  readonly parentKind: number // most likely 1111
+  readonly content: string
+  readonly created_at?: number
+}
+
+export function buildReplyCommunityPost(t: CommunityReplyTemplate): EventTemplate {
+  const a = `${CommunityDefinitionKind}:${t.community.ownerPubkey}:${t.community.d}`
+  const tags: string[][] = [
+    ["A", a, ...(t.community.relay ? [t.community.relay] : [])],
+    ["P", t.community.ownerPubkey, ...(t.community.relay ? [t.community.relay] : [])],
+    ["K", String(CommunityDefinitionKind)],
+    ["e", t.parentEventId, ...(t.community.relay ? [t.community.relay] : [])],
+    ["p", t.parentAuthorPubkey, ...(t.community.relay ? [t.community.relay] : [])],
+    ["k", String(t.parentKind)],
+  ]
+  return {
+    kind: CommunityPostKind,
+    content: t.content,
+    created_at: t.created_at ?? Math.floor(Date.now() / 1000),
+    tags,
+  }
+}
+
+export function signCommunityPost(t: CommunityTopPostTemplate | CommunityReplyTemplate, sk: Uint8Array): Event {
+  const tmpl = (t as any).parentEventId ? buildReplyCommunityPost(t as CommunityReplyTemplate) : buildTopLevelCommunityPost(t as CommunityTopPostTemplate)
+  return finalizeEvent(tmpl, sk)
+}
+
+// -----------------------------------------------------------------------------
+// Approval (kind 4550)
+// -----------------------------------------------------------------------------
+
+export interface CommunityApprovalTemplate {
+  readonly community: CommunityPointer
+  readonly post: Event
+  readonly postAuthorPubkey: string
+  readonly postRequestKind: number // e.g., 1111
+  readonly content?: string // optional override; defaults to JSON of post
+  readonly created_at?: number
+}
+
+export function buildCommunityApproval(t: CommunityApprovalTemplate): EventTemplate {
+  const a = `${CommunityDefinitionKind}:${t.community.ownerPubkey}:${t.community.d}`
+  const tags: string[][] = [
+    ["a", a, ...(t.community.relay ? [t.community.relay] : [])],
+    ["e", t.post.id, ...(t.community.relay ? [t.community.relay] : [])],
+    ["p", t.postAuthorPubkey, ...(t.community.relay ? [t.community.relay] : [])],
+    ["k", String(t.postRequestKind)],
+  ]
+  const content = t.content ?? JSON.stringify(t.post)
+  return {
+    kind: CommunityApprovalKind,
+    content,
+    created_at: t.created_at ?? Math.floor(Date.now() / 1000),
+    tags,
+  }
+}
+
+export function signCommunityApproval(t: CommunityApprovalTemplate, sk: Uint8Array): Event {
+  return finalizeEvent(buildCommunityApproval(t), sk)
+}
+


### PR DESCRIPTION
- Add wrappers/nip72.ts with builders for community definition (34550), community posts (1111), and approvals (4550)
- Add tests: src/wrappers/nip72.test.ts covering definitions, top-level posts, replies, and approvals
- Update docs/SUPPORTED_NIPS.md and docs/UNSUPPORTED_NIPS.md; export nip72 in package.json

All changes pass `bun run verify`.