### PR TITLE
feat: NIP-68 Picture-first feeds (builders + tests)

### DIFF
--- a/docs/SUPPORTED_NIPS.md
+++ b/docs/SUPPORTED_NIPS.md
@@ -72,6 +72,7 @@ Keep this file up to date whenever adding or removing support.
 | 43 | Relay access metadata/requests | `~/code/nips/43.md` | `src/wrappers/nip43.ts` | `src/wrappers/nip43.test.ts` |
 | 84 | Highlights | `~/code/nips/84.md` | `src/wrappers/nip84.ts` | `src/wrappers/nip84.test.ts` |
 | 72 | Moderated communities | `~/code/nips/72.md` | `src/wrappers/nip72.ts` | `src/wrappers/nip72.test.ts` |
+| 68 | Picture-first feeds | `~/code/nips/68.md` | `src/wrappers/nip68.ts` | `src/wrappers/nip68.test.ts` |
 
 Notes
 - Registry modules live under `src/relay/core/nip/modules/**`. Default relay modules: NIP-01, NIP-11, NIP-16/33. Others (e.g., NIP-28, NIP-57, NIP-42) are available but may not be in `DefaultModules`.

--- a/docs/UNSUPPORTED_NIPS.md
+++ b/docs/UNSUPPORTED_NIPS.md
@@ -18,7 +18,6 @@ Source of truth for supported NIPs: `docs/SUPPORTED_NIPS.md`.
 - 60 — `~/code/nips/60.md`
 - 61 — `~/code/nips/61.md`
 - 64 — `~/code/nips/64.md`
-- 68 — `~/code/nips/68.md`
 - 69 — `~/code/nips/69.md`
 - 73 — `~/code/nips/73.md`
 - 77 — `~/code/nips/77.md`

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "./nip72": "./src/wrappers/nip72.ts",
     "./nip84": "./src/wrappers/nip84.ts",
     "./nip56": "./src/wrappers/nip56.ts",
+    "./nip68": "./src/wrappers/nip68.ts",
     "./nip27": "./src/wrappers/nip27.ts",
     "./nip28": "./src/wrappers/nip28.ts",
     "./nip30": "./src/wrappers/nip30.ts",

--- a/src/wrappers/nip68.test.ts
+++ b/src/wrappers/nip68.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Tests for NIP-68 Picture-first feeds (kind 20)
+ */
+import { describe, test, expect } from "bun:test"
+import { generateSecretKey, verifyEvent } from "./pure.js"
+import { buildImetaTag, signPictureEvent, parseImetaTag, AllowedMediaTypes, PictureEventKind } from "./nip68.js"
+
+describe("NIP-68 Picture Events", () => {
+  test("build and sign picture event with two images + fallbacks + annotate-user", () => {
+    const sk = generateSecretKey()
+    const evt = signPictureEvent({
+      title: "Costa Rica Trip",
+      description: "Scenic shots",
+      images: [
+        {
+          url: "https://nostr.build/i/1.jpg",
+          mime: "image/jpeg",
+          blurhash: "eAbcd",
+          dim: "3024x4032",
+          alt: "Overlook",
+          sha256: "a".repeat(64),
+          fallbacks: ["https://nostrcheck.me/1.jpg", "https://void.cat/1.jpg"],
+        },
+        {
+          url: "https://nostr.build/i/2.jpg",
+          mime: "image/jpeg",
+          alt: "Beach",
+          annotateUsers: [{ pubkey: "b".repeat(64), x: 100, y: 250 }],
+        },
+      ],
+      mediaTypeFilter: "image/jpeg",
+      hashtags: ["travel", "beach"],
+      location: "Tamarindo, Costa Rica",
+      geohash: "dr5r7",
+      languages: [{ L: "ISO-639-1" }, { l: "en", L: "ISO-639-1" }],
+    }, sk)
+
+    expect(evt.kind).toBe(PictureEventKind)
+    const title = evt.tags.find((t) => t[0] === "title")
+    expect(title?.[1]).toBe("Costa Rica Trip")
+    const imetaTags = evt.tags.filter((t) => t[0] === "imeta")
+    expect(imetaTags.length).toBe(2)
+    const parsed0 = parseImetaTag(imetaTags[0]!)
+    const parsed1 = parseImetaTag(imetaTags[1]!)
+    expect(parsed0?.url).toBe("https://nostr.build/i/1.jpg")
+    expect(parsed1?.annotateUsers?.[0]?.x).toBe(100)
+    const m = evt.tags.find((t) => t[0] === "m")
+    expect(m?.[1]).toBe("image/jpeg")
+    expect(verifyEvent(evt)).toBe(true)
+  })
+
+  test("invalid media type throws", () => {
+    expect(() => buildImetaTag({ url: "https://img", mime: "image/xyz" })).toThrow()
+    expect(AllowedMediaTypes.has("image/jpeg")).toBe(true)
+  })
+})

--- a/src/wrappers/nip68.ts
+++ b/src/wrappers/nip68.ts
@@ -1,0 +1,150 @@
+/**
+ * NIP-68: Picture-first feeds (kind 20)
+ * Spec: ~/code/nips/68.md
+ */
+import type { Event, EventTemplate } from "./pure.js"
+import { finalizeEvent } from "./pure.js"
+
+export const PictureEventKind = 20
+
+// Allowed media types per spec
+export const AllowedMediaTypes = new Set([
+  "image/apng",
+  "image/avif",
+  "image/gif",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+])
+
+export interface AnnotateUser {
+  readonly pubkey: string
+  readonly x: number
+  readonly y: number
+}
+
+export interface PictureImeta {
+  readonly url: string
+  readonly mime: string
+  readonly blurhash?: string
+  readonly dim?: string // e.g., "3024x4032"
+  readonly alt?: string
+  readonly sha256?: string // NIP-94 'x' value
+  readonly fallbacks?: readonly string[]
+  readonly annotateUsers?: readonly AnnotateUser[]
+}
+
+export interface PictureTemplate {
+  readonly title: string
+  readonly description?: string
+  readonly images: readonly PictureImeta[]
+  readonly taggedPubkeys?: readonly { pubkey: string; relay?: string }[]
+  readonly contentWarning?: string
+  readonly mediaTypeFilter?: string // e.g., "image/jpeg"
+  readonly hashes?: readonly string[] // add 'x' tags per image hash
+  readonly hashtags?: readonly string[]
+  readonly location?: string
+  readonly geohash?: string
+  readonly languages?: readonly { l?: string; L?: string }[] // NIP-32 labels for language
+  readonly created_at?: number
+}
+
+/** Build one `imeta` tag */
+export function buildImetaTag(imeta: PictureImeta): string[] {
+  if (!AllowedMediaTypes.has(imeta.mime)) {
+    throw new Error(`Unsupported media type: ${imeta.mime}`)
+  }
+  const tag: string[] = [
+    "imeta",
+    `url ${imeta.url}`,
+    `m ${imeta.mime}`,
+  ]
+  if (imeta.blurhash) tag.push(`blurhash ${imeta.blurhash}`)
+  if (imeta.dim) tag.push(`dim ${imeta.dim}`)
+  if (imeta.alt) tag.push(`alt ${imeta.alt}`)
+  if (imeta.sha256) tag.push(`x ${imeta.sha256}`)
+  if (imeta.fallbacks) for (const f of imeta.fallbacks) tag.push(`fallback ${f}`)
+  if (imeta.annotateUsers) {
+    for (const a of imeta.annotateUsers) {
+      tag.push(`annotate-user ${a.pubkey}:${a.x}:${a.y}`)
+    }
+  }
+  return tag
+}
+
+/** Build a picture event template (kind 20) */
+export function buildPictureEvent(t: PictureTemplate): EventTemplate {
+  const tags: string[][] = [["title", t.title]]
+  for (const im of t.images) tags.push(buildImetaTag(im))
+  if (t.contentWarning) tags.push(["content-warning", t.contentWarning])
+  if (t.taggedPubkeys) for (const p of t.taggedPubkeys) tags.push(["p", p.pubkey, ...(p.relay ? [p.relay] : [])])
+  if (t.mediaTypeFilter) tags.push(["m", t.mediaTypeFilter])
+  if (t.hashes) for (const h of t.hashes) tags.push(["x", h])
+  if (t.hashtags) for (const h of t.hashtags) tags.push(["t", h])
+  if (t.location) tags.push(["location", t.location])
+  if (t.geohash) tags.push(["g", t.geohash])
+  if (t.languages) {
+    for (const lang of t.languages) {
+      if (lang.L) tags.push(["L", lang.L])
+      if (lang.l) tags.push(["l", lang.l, lang.L ?? ""]) // include namespace if provided
+    }
+  }
+  return {
+    kind: PictureEventKind,
+    content: t.description ?? "",
+    created_at: t.created_at ?? Math.floor(Date.now() / 1000),
+    tags,
+  }
+}
+
+export function signPictureEvent(t: PictureTemplate, sk: Uint8Array): Event {
+  return finalizeEvent(buildPictureEvent(t), sk)
+}
+
+/** Parse an `imeta` tag back into a structured object */
+export function parseImetaTag(tag: string[]): PictureImeta | null {
+  if (tag[0] !== "imeta") return null
+  let url = ""
+  let mime = ""
+  let blurhash: string | undefined
+  let dim: string | undefined
+  let alt: string | undefined
+  let sha256: string | undefined
+  const fallbacks: string[] = []
+  const annotateUsers: AnnotateUser[] = []
+
+  for (let i = 1; i < tag.length; i++) {
+    const part = tag[i]!
+    const [key, ...rest] = part.split(" ")
+    const val = rest.join(" ")
+    switch (key) {
+      case "url": url = val; break
+      case "m": mime = val; break
+      case "blurhash": blurhash = val; break
+      case "dim": dim = val; break
+      case "alt": alt = val; break
+      case "x": sha256 = val; break
+      case "fallback": fallbacks.push(val); break
+      case "annotate-user": {
+        const [pubkey, xs, ys] = val.split(":")
+        const x = Number(xs)
+        const y = Number(ys)
+        if (pubkey && Number.isFinite(x) && Number.isFinite(y)) {
+          annotateUsers.push({ pubkey, x, y })
+        }
+        break
+      }
+      default: break
+    }
+  }
+
+  if (!url || !mime) return null
+  const obj: any = { url, mime }
+  if (blurhash !== undefined) obj.blurhash = blurhash
+  if (dim !== undefined) obj.dim = dim
+  if (alt !== undefined) obj.alt = alt
+  if (sha256 !== undefined) obj.sha256 = sha256
+  if (fallbacks.length > 0) obj.fallbacks = fallbacks
+  if (annotateUsers.length > 0) obj.annotateUsers = annotateUsers
+  return obj as PictureImeta
+}


### PR DESCRIPTION
- Add wrappers/nip68.ts with imeta builder, picture event builder, and parser
- Add tests: src/wrappers/nip68.test.ts covering two images, fallbacks, annotate-user, and invalid media type
- Update docs/SUPPORTED_NIPS.md and docs/UNSUPPORTED_NIPS.md; export nip68 in package.json

All changes pass `bun run verify`.