### PR TITLE
feat: NIP-69 P2P Orders (builders + tests)

### DIFF
--- a/docs/SUPPORTED_NIPS.md
+++ b/docs/SUPPORTED_NIPS.md
@@ -73,6 +73,7 @@ Keep this file up to date whenever adding or removing support.
 | 84 | Highlights | `~/code/nips/84.md` | `src/wrappers/nip84.ts` | `src/wrappers/nip84.test.ts` |
 | 72 | Moderated communities | `~/code/nips/72.md` | `src/wrappers/nip72.ts` | `src/wrappers/nip72.test.ts` |
 | 68 | Picture-first feeds | `~/code/nips/68.md` | `src/wrappers/nip68.ts` | `src/wrappers/nip68.test.ts` |
+| 69 | Peer-to-peer orders | `~/code/nips/69.md` | `src/wrappers/nip69.ts` | `src/wrappers/nip69.test.ts` |
 
 Notes
 - Registry modules live under `src/relay/core/nip/modules/**`. Default relay modules: NIP-01, NIP-11, NIP-16/33. Others (e.g., NIP-28, NIP-57, NIP-42) are available but may not be in `DefaultModules`.

--- a/docs/UNSUPPORTED_NIPS.md
+++ b/docs/UNSUPPORTED_NIPS.md
@@ -18,7 +18,6 @@ Source of truth for supported NIPs: `docs/SUPPORTED_NIPS.md`.
 - 60 — `~/code/nips/60.md`
 - 61 — `~/code/nips/61.md`
 - 64 — `~/code/nips/64.md`
-- 69 — `~/code/nips/69.md`
 - 73 — `~/code/nips/73.md`
 - 77 — `~/code/nips/77.md`
 - 86 — `~/code/nips/86.md`

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "./nip84": "./src/wrappers/nip84.ts",
     "./nip56": "./src/wrappers/nip56.ts",
     "./nip68": "./src/wrappers/nip68.ts",
+    "./nip69": "./src/wrappers/nip69.ts",
     "./nip27": "./src/wrappers/nip27.ts",
     "./nip28": "./src/wrappers/nip28.ts",
     "./nip30": "./src/wrappers/nip30.ts",

--- a/src/wrappers/nip69.test.ts
+++ b/src/wrappers/nip69.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Tests for NIP-69 Peer-to-peer Order events (kind 38383)
+ */
+import { describe, test, expect } from "bun:test"
+import { generateSecretKey, verifyEvent } from "./pure.js"
+import { signP2POrder, P2POrderKind } from "./nip69.js"
+
+describe("NIP-69 P2P Orders", () => {
+  test("build and sign full order with rating and platform", () => {
+    const sk = generateSecretKey()
+    const order = signP2POrder({
+      idD: "uuid-123",
+      type: "sell",
+      currency: "USD",
+      status: "pending",
+      amountSats: "0",
+      fiatAmount: ["100", "200"],
+      paymentMethods: ["bank transfer", "face to face"],
+      premiumPct: "1",
+      ratingJson: JSON.stringify({ total_reviews: 1, total_rating: 3.0, last_rating: 3, max_rate: 5, min_rate: 1 }),
+      sourceUrl: "https://example.com/order/123",
+      network: "mainnet",
+      layer: "lightning",
+      name: "Nakamoto",
+      geohash: "u4pruydqqvj",
+      bond: "0",
+      expiresAt: String(Math.floor(Date.now() / 1000) + 3600),
+      expiration: String(Math.floor(Date.now() / 1000) + 7200),
+      platform: "lnp2pbot",
+      document: "order",
+    }, sk)
+
+    expect(order.kind).toBe(P2POrderKind)
+    const d = order.tags.find((t) => t[0] === "d")
+    const k = order.tags.find((t) => t[0] === "k")
+    const f = order.tags.find((t) => t[0] === "f")
+    const s = order.tags.find((t) => t[0] === "s")
+    const amt = order.tags.find((t) => t[0] === "amt")
+    const fa = order.tags.find((t) => t[0] === "fa")
+    const pm = order.tags.find((t) => t[0] === "pm")
+    const premium = order.tags.find((t) => t[0] === "premium")
+    const rating = order.tags.find((t) => t[0] === "rating")
+    const y = order.tags.find((t) => t[0] === "y")
+    const z = order.tags.find((t) => t[0] === "z")
+
+    expect(d?.[1]).toBe("uuid-123")
+    expect(k?.[1]).toBe("sell")
+    expect(f?.[1]).toBe("USD")
+    expect(s?.[1]).toBe("pending")
+    expect(amt?.[1]).toBe("0")
+    expect(fa?.[1]).toBe("100")
+    expect(fa?.[2]).toBe("200")
+    expect(pm?.[1]).toContain("bank transfer")
+    expect(premium?.[1]).toBe("1")
+    expect(() => JSON.parse(rating?.[1] ?? "{}")).not.toThrow()
+    expect(y?.[1]).toBe("lnp2pbot")
+    expect(z?.[1]).toBe("order")
+    expect(verifyEvent(order)).toBe(true)
+  })
+})

--- a/src/wrappers/nip69.ts
+++ b/src/wrappers/nip69.ts
@@ -1,0 +1,76 @@
+/**
+ * NIP-69: Peer-to-peer Order events (kind 38383)
+ * Spec: ~/code/nips/69.md
+ */
+import type { Event, EventTemplate } from "./pure.js"
+import { finalizeEvent } from "./pure.js"
+
+export const P2POrderKind = 38383
+
+export type OrderType = "sell" | "buy"
+export type OrderStatus = "pending" | "canceled" | "in-progress" | "success" | "expired"
+
+export interface P2POrderTemplate {
+  readonly idD: string // d tag (unique identifier)
+  readonly type: OrderType // k tag
+  readonly currency: string // f tag (ISO 4217)
+  readonly status: OrderStatus // s tag
+  readonly amountSats: string // amt tag (string per spec)
+  readonly fiatAmount: string | readonly [string, string] // fa tag (single or range)
+  readonly paymentMethods?: readonly string[] // pm tag (comma-joined if many)
+  readonly premiumPct?: string // premium tag (percentage string)
+  readonly sourceUrl?: string // source tag
+  readonly ratingJson?: string // rating tag JSON
+  readonly network?: string // network tag
+  readonly layer?: string // layer tag
+  readonly name?: string // name tag
+  readonly geohash?: string // g tag
+  readonly bond?: string // bond tag
+  readonly expiresAt?: string // expires_at tag (timestamp)
+  readonly expiration?: string // expiration tag (NIP-40 timestamp)
+  readonly platform?: string // y tag
+  readonly document?: string // z tag (typically "order")
+  readonly content?: string
+  readonly created_at?: number
+}
+
+export function buildP2POrder(t: P2POrderTemplate): EventTemplate {
+  const tags: string[][] = []
+
+  // Mandatory
+  tags.push(["d", t.idD])
+  tags.push(["k", t.type])
+  tags.push(["f", t.currency])
+  tags.push(["s", t.status])
+  tags.push(["amt", String(t.amountSats)])
+
+  // Fiat amount (single or range)
+  if (Array.isArray(t.fiatAmount)) tags.push(["fa", t.fiatAmount[0]!, t.fiatAmount[1]!])
+  else tags.push(["fa", String(t.fiatAmount)])
+
+  if (t.paymentMethods && t.paymentMethods.length > 0) tags.push(["pm", t.paymentMethods.join(", ")])
+  if (t.premiumPct) tags.push(["premium", t.premiumPct])
+  if (t.ratingJson) tags.push(["rating", t.ratingJson])
+  if (t.sourceUrl) tags.push(["source", t.sourceUrl])
+  if (t.network) tags.push(["network", t.network])
+  if (t.layer) tags.push(["layer", t.layer])
+  if (t.name) tags.push(["name", t.name])
+  if (t.geohash) tags.push(["g", t.geohash])
+  if (t.bond) tags.push(["bond", t.bond])
+  if (t.expiresAt) tags.push(["expires_at", t.expiresAt])
+  if (t.expiration) tags.push(["expiration", t.expiration])
+  if (t.platform) tags.push(["y", t.platform])
+  if (t.document) tags.push(["z", t.document])
+
+  return {
+    kind: P2POrderKind,
+    content: t.content ?? "",
+    created_at: t.created_at ?? Math.floor(Date.now() / 1000),
+    tags,
+  }
+}
+
+export function signP2POrder(t: P2POrderTemplate, sk: Uint8Array): Event {
+  return finalizeEvent(buildP2POrder(t), sk)
+}
+


### PR DESCRIPTION
- Add wrappers/nip69.ts for building/signing kind 38383 order events
- Add tests: src/wrappers/nip69.test.ts for required/optional tags
- Update docs/SUPPORTED_NIPS.md and docs/UNSUPPORTED_NIPS.md; export nip69 in package.json

All changes pass `bun run verify`.