### PR TITLE
feat: NIP-73 External Content IDs (helpers + tests)

### DIFF
--- a/docs/SUPPORTED_NIPS.md
+++ b/docs/SUPPORTED_NIPS.md
@@ -74,6 +74,7 @@ Keep this file up to date whenever adding or removing support.
 | 72 | Moderated communities | `~/code/nips/72.md` | `src/wrappers/nip72.ts` | `src/wrappers/nip72.test.ts` |
 | 68 | Picture-first feeds | `~/code/nips/68.md` | `src/wrappers/nip68.ts` | `src/wrappers/nip68.test.ts` |
 | 69 | Peer-to-peer orders | `~/code/nips/69.md` | `src/wrappers/nip69.ts` | `src/wrappers/nip69.test.ts` |
+| 73 | External content IDs | `~/code/nips/73.md` | `src/wrappers/nip73.ts` | `src/wrappers/nip73.test.ts` |
 
 Notes
 - Registry modules live under `src/relay/core/nip/modules/**`. Default relay modules: NIP-01, NIP-11, NIP-16/33. Others (e.g., NIP-28, NIP-57, NIP-42) are available but may not be in `DefaultModules`.

--- a/docs/UNSUPPORTED_NIPS.md
+++ b/docs/UNSUPPORTED_NIPS.md
@@ -18,7 +18,6 @@ Source of truth for supported NIPs: `docs/SUPPORTED_NIPS.md`.
 - 60 — `~/code/nips/60.md`
 - 61 — `~/code/nips/61.md`
 - 64 — `~/code/nips/64.md`
-- 73 — `~/code/nips/73.md`
 - 77 — `~/code/nips/77.md`
 - 86 — `~/code/nips/86.md`
 - 92 — `~/code/nips/92.md`

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "./nip56": "./src/wrappers/nip56.ts",
     "./nip68": "./src/wrappers/nip68.ts",
     "./nip69": "./src/wrappers/nip69.ts",
+    "./nip73": "./src/wrappers/nip73.ts",
     "./nip27": "./src/wrappers/nip27.ts",
     "./nip28": "./src/wrappers/nip28.ts",
     "./nip30": "./src/wrappers/nip30.ts",

--- a/src/wrappers/nip73.test.ts
+++ b/src/wrappers/nip73.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Tests for NIP-73 External Content IDs
+ */
+import { describe, test, expect } from "bun:test"
+import { generateSecretKey, verifyEvent } from "./pure.js"
+import { buildIAndKTags, signExternalIdEvent } from "./nip73.js"
+
+describe("NIP-73 External Content IDs", () => {
+  test("web URL normalization + k=web", () => {
+    const sk = generateSecretKey()
+    const evt = signExternalIdEvent({
+      kind: 1,
+      content: "webref",
+      externals: [{ k: "web", i: "https://example.com/path#frag" }],
+    }, sk)
+    const itag = evt.tags.find((t) => t[0] === "i")
+    const ktag = evt.tags.find((t) => t[0] === "k")
+    expect(itag?.[1]).toBe("https://example.com/path")
+    expect(ktag?.[1]).toBe("web")
+    expect(verifyEvent(evt)).toBe(true)
+  })
+
+  test("isbn + podcast guids + hashtag + blockchain", () => {
+    const sk = generateSecretKey()
+    const evt = signExternalIdEvent({
+      kind: 1,
+      externals: [
+        { k: "isbn", i: "isbn:9780765382030" },
+        { k: "podcast:guid", i: "podcast:guid:c90e609a-df1e-596a-bd5e-57bcc8aad6cc", urlHint: "https://podcastindex.org/podcast/c90e..." },
+        { k: "#", i: "#nostr" },
+        { k: "bitcoin:tx", i: "bitcoin:tx:a1075db55d416d3ca199f55b6084e2115b9345e16c5cf302fc80e9d5fbf5d48d" },
+        { k: "ethereum:address", i: "ethereum:1:address:0xd8da6bf26964af9d7eed9e03e53415d37aa96045" },
+      ],
+    }, sk)
+    const tags = evt.tags
+    const iVals = tags.filter((t) => t[0] === "i").map((t) => t[1])
+    const kVals = tags.filter((t) => t[0] === "k").map((t) => t[1])
+    expect(iVals).toContain("isbn:9780765382030")
+    expect(kVals).toContain("isbn")
+    expect(iVals.find((x) => x?.startsWith("podcast:guid:"))).toBeTruthy()
+    expect(kVals).toContain("podcast:guid")
+    expect(iVals).toContain("#nostr")
+    expect(kVals).toContain("#")
+    expect(kVals).toContain("bitcoin:tx")
+    expect(kVals).toContain("ethereum:address")
+    expect(verifyEvent(evt)).toBe(true)
+  })
+
+  test("i tag may include url hint as second arg", () => {
+    const pair = buildIAndKTags({ k: "isan", i: "isan:0000-0000-401A-0000", urlHint: "https://www.imdb.com/title/tt0120737" })
+    const it = pair[0]!
+    const kt = pair[1]!
+    expect(it[0]).toBe("i")
+    expect(it[2]).toBe("https://www.imdb.com/title/tt0120737")
+    expect(kt[0]).toBe("k")
+    expect(kt[1]).toBe("isan")
+  })
+})

--- a/src/wrappers/nip73.ts
+++ b/src/wrappers/nip73.ts
@@ -1,0 +1,70 @@
+/**
+ * NIP-73: External Content IDs
+ * Spec: ~/code/nips/73.md
+ */
+import type { Event, EventTemplate } from "./pure.js"
+import { finalizeEvent } from "./pure.js"
+
+export type ExternalKind =
+  | "web"
+  | "isbn"
+  | "geo"
+  | "isan"
+  | "doi"
+  | "#"
+  | "podcast:guid"
+  | "podcast:item:guid"
+  | "podcast:publisher:guid"
+  | `${string}:tx`
+  | `${string}:address`
+
+export interface ExternalId {
+  readonly k: ExternalKind
+  readonly i: string
+  readonly urlHint?: string
+}
+
+export interface ExternalIdEventTemplate {
+  readonly kind: number
+  readonly content?: string
+  readonly externals: readonly ExternalId[]
+  readonly created_at?: number
+  readonly extraTags?: readonly string[][]
+}
+
+const normalizeUrl = (url: string): string => {
+  try {
+    const u = new URL(url)
+    u.hash = ""
+    return u.toString().replace(/\/$/, "")
+  } catch {
+    return url
+  }
+}
+
+/** Build i/k tag pair */
+export function buildIAndKTags(ext: ExternalId): string[][] {
+  const iVal = ext.k === "web" ? normalizeUrl(ext.i) : ext.i
+  const itag: string[] = ["i", iVal]
+  if (ext.urlHint) itag.push(ext.urlHint)
+  const ktag: string[] = ["k", ext.k]
+  return [itag, ktag]
+}
+
+/** Build a template with i/k pairs */
+export function buildExternalIdEvent(t: ExternalIdEventTemplate): EventTemplate {
+  const tags: string[][] = []
+  for (const e of t.externals) tags.push(...buildIAndKTags(e))
+  if (t.extraTags) tags.push(...t.extraTags.map((x) => x.slice()))
+  return {
+    kind: t.kind,
+    content: t.content ?? "",
+    created_at: t.created_at ?? Math.floor(Date.now() / 1000),
+    tags,
+  }
+}
+
+export function signExternalIdEvent(t: ExternalIdEventTemplate, sk: Uint8Array): Event {
+  return finalizeEvent(buildExternalIdEvent(t), sk)
+}
+


### PR DESCRIPTION
- Add wrappers/nip73.ts: build i/k tags, event builder/signers; URL normalization for web
- Add tests: src/wrappers/nip73.test.ts covering web, isbn, podcast, hashtag, blockchain, url hints
- Update docs/SUPPORTED_NIPS.md and docs/UNSUPPORTED_NIPS.md; export nip73 in package.json

All changes pass `bun run verify`.