### PR TITLE
feat: NIP-35 Torrents (builders + tests)

### DIFF
--- a/docs/SUPPORTED_NIPS.md
+++ b/docs/SUPPORTED_NIPS.md
@@ -76,6 +76,7 @@ Keep this file up to date whenever adding or removing support.
 | 69 | Peer-to-peer orders | `~/code/nips/69.md` | `src/wrappers/nip69.ts` | `src/wrappers/nip69.test.ts` |
 | 73 | External content IDs | `~/code/nips/73.md` | `src/wrappers/nip73.ts` | `src/wrappers/nip73.test.ts` |
 | 96 | HTTP file storage | `~/code/nips/96.md` | `src/wrappers/nip96.ts` | `src/wrappers/nip96.test.ts` |
+| 35 | Torrents | `~/code/nips/35.md` | `src/wrappers/nip35.ts` | `src/wrappers/nip35.test.ts` |
 
 Notes
 - Registry modules live under `src/relay/core/nip/modules/**`. Default relay modules: NIP-01, NIP-11, NIP-16/33. Others (e.g., NIP-28, NIP-57, NIP-42) are available but may not be in `DefaultModules`.

--- a/docs/UNSUPPORTED_NIPS.md
+++ b/docs/UNSUPPORTED_NIPS.md
@@ -11,7 +11,6 @@ Source of truth for supported NIPs: `docs/SUPPORTED_NIPS.md`.
 - 15 — `~/code/nips/15.md`
 - 22 — `~/code/nips/22.md`
 - 24 — `~/code/nips/24.md`
-- 35 — `~/code/nips/35.md`
 - 37 — `~/code/nips/37.md`
 - 38 — `~/code/nips/38.md`
 - 55 — `~/code/nips/55.md`

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "./nip43": "./src/wrappers/nip43.ts",
     "./nip72": "./src/wrappers/nip72.ts",
     "./nip84": "./src/wrappers/nip84.ts",
+    "./nip35": "./src/wrappers/nip35.ts",
     "./nip56": "./src/wrappers/nip56.ts",
     "./nip68": "./src/wrappers/nip68.ts",
     "./nip69": "./src/wrappers/nip69.ts",

--- a/src/wrappers/nip35.test.ts
+++ b/src/wrappers/nip35.test.ts
@@ -1,0 +1,54 @@
+/**
+ * Tests for NIP-35 Torrents
+ */
+import { describe, test, expect } from "bun:test"
+import { generateSecretKey, verifyEvent } from "./pure.js"
+import { signTorrentEvent, magnetFromTorrent, signTorrentComment, TorrentKind, TorrentCommentKind } from "./nip35.js"
+
+describe("NIP-35 Torrents", () => {
+  test("build and sign torrent event and magnet link", () => {
+    const sk = generateSecretKey()
+    const evt = signTorrentEvent({
+      title: "Example Torrent",
+      infoHash: "a".repeat(40),
+      description: "A sample torrent",
+      files: [
+        { path: "info/example.txt", sizeBytes: 1234 },
+        { path: "info/sub/other.bin" },
+      ],
+      trackers: ["udp://tracker.example:1337", "http://tracker2/announce"],
+      externals: [
+        { value: "tcat:video,movie,4k" },
+        { value: "imdb:tt15239678" },
+      ],
+      hashtags: ["movie", "4k"],
+    }, sk)
+
+    expect(evt.kind).toBe(TorrentKind)
+    const title = evt.tags.find((t) => t[0] === "title")?.[1]
+    const x = evt.tags.find((t) => t[0] === "x")?.[1]
+    const file = evt.tags.find((t) => t[0] === "file")
+    const ext = evt.tags.find((t) => t[0] === "i")
+    expect(title).toBe("Example Torrent")
+    expect(x).toBe("a".repeat(40))
+    expect(file?.[1]).toBe("info/example.txt")
+    expect(ext?.[1]).toContain("tcat:")
+    expect(verifyEvent(evt)).toBe(true)
+
+    const magnet = magnetFromTorrent(evt)
+    expect(magnet.startsWith("magnet:?xt=urn:btih:")).toBe(true)
+    expect(magnet).toContain("&tr=")
+  })
+
+  test("build and sign torrent comment (kind 2004)", () => {
+    const sk = generateSecretKey()
+    const parent = signTorrentEvent({ title: "T", infoHash: "b".repeat(40) }, generateSecretKey())
+    const comment = signTorrentComment({ parentId: parent.id, parentAuthor: parent.pubkey, content: "Nice!", relayHint: "wss://relay.example" }, sk)
+    expect(comment.kind).toBe(TorrentCommentKind)
+    const e = comment.tags.find((t) => t[0] === "e")
+    const p = comment.tags.find((t) => t[0] === "p")
+    expect(e?.[1]).toBe(parent.id)
+    expect(p?.[1]).toBe(parent.pubkey)
+    expect(verifyEvent(comment)).toBe(true)
+  })
+})

--- a/src/wrappers/nip35.ts
+++ b/src/wrappers/nip35.ts
@@ -1,0 +1,105 @@
+/**
+ * NIP-35: Torrents
+ * Spec: ~/code/nips/35.md
+ */
+import type { Event, EventTemplate } from "./pure.js"
+import { finalizeEvent } from "./pure.js"
+
+export const TorrentKind = 2003
+export const TorrentCommentKind = 2004
+
+export interface TorrentFileEntry {
+  readonly path: string // full path, e.g. info/example.txt
+  readonly sizeBytes?: number | string
+}
+
+export interface TorrentExternalRef {
+  /**
+   * i-tag value, e.g. "tcat:video,movie,4k", "newznab:2045", "imdb:tt15239678",
+   * "tmdb:movie:693134", "ttvdb:movie:290272"
+   */
+  readonly value: string
+}
+
+export interface BuildTorrentParams {
+  readonly title: string
+  readonly infoHash: string // V1 btih (hex) for x tag
+  readonly description?: string
+  readonly files?: readonly TorrentFileEntry[]
+  readonly trackers?: readonly string[]
+  readonly externals?: readonly TorrentExternalRef[]
+  readonly hashtags?: readonly string[]
+  readonly created_at?: number
+}
+
+export function buildTorrentEvent(p: BuildTorrentParams): EventTemplate {
+  const tags: string[][] = [["title", p.title], ["x", p.infoHash]]
+  if (p.files) {
+    for (const f of p.files) {
+      const arr: string[] = ["file", f.path]
+      if (f.sizeBytes !== undefined) arr.push(String(f.sizeBytes))
+      tags.push(arr)
+    }
+  }
+  if (p.trackers) {
+    for (const tr of p.trackers) tags.push(["tracker", tr])
+  }
+  if (p.externals) {
+    for (const ext of p.externals) tags.push(["i", ext.value])
+  }
+  if (p.hashtags) {
+    for (const t of p.hashtags) tags.push(["t", t])
+  }
+  return {
+    kind: TorrentKind,
+    content: p.description ?? "",
+    created_at: p.created_at ?? Math.floor(Date.now() / 1000),
+    tags,
+  }
+}
+
+export function signTorrentEvent(p: BuildTorrentParams, sk: Uint8Array): Event {
+  return finalizeEvent(buildTorrentEvent(p), sk)
+}
+
+/** Build a magnet link from a torrent event (kind 2003) */
+export function magnetFromTorrent(evt: Event): string {
+  const x = evt.tags.find((t) => t[0] === "x")?.[1]
+  if (!x) throw new Error("missing x (info hash)")
+  const title = evt.tags.find((t) => t[0] === "title")?.[1]
+  const trackers = evt.tags.filter((t) => t[0] === "tracker").map((t) => t[1]!).filter(Boolean)
+  const params: string[] = []
+  params.push(`xt=urn:btih:${encodeURIComponent(x)}`)
+  if (title) params.push(`dn=${encodeURIComponent(title)}`)
+  for (const tr of trackers) params.push(`tr=${encodeURIComponent(tr)}`)
+  return `magnet:?${params.join("&")}`
+}
+
+export interface BuildTorrentCommentParams {
+  readonly parentId: string
+  readonly parentAuthor: string
+  readonly content: string
+  readonly relayHint?: string
+  readonly created_at?: number
+}
+
+/** Build a torrent comment (kind 2004) that follows NIP-10 reply tagging */
+export function buildTorrentComment(p: BuildTorrentCommentParams): EventTemplate {
+  const eTag: string[] = ["e", p.parentId]
+  const pTag: string[] = ["p", p.parentAuthor]
+  if (p.relayHint) {
+    eTag.push(p.relayHint)
+    pTag.push(p.relayHint)
+  }
+  return {
+    kind: TorrentCommentKind,
+    content: p.content,
+    created_at: p.created_at ?? Math.floor(Date.now() / 1000),
+    tags: [eTag, pTag],
+  }
+}
+
+export function signTorrentComment(p: BuildTorrentCommentParams, sk: Uint8Array): Event {
+  return finalizeEvent(buildTorrentComment(p), sk)
+}
+


### PR DESCRIPTION
- Add wrappers/nip35.ts: build/sign torrent events (2003), magnet link from tags, and torrent comments (2004)
- Add tests: src/wrappers/nip35.test.ts for torrent and comments
- Update docs/SUPPORTED_NIPS.md and docs/UNSUPPORTED_NIPS.md; export nip35 in package.json

All changes pass `bun run verify`.