### PR TITLE
feat: NIP-37 Draft Wraps (helpers + tests)

### DIFF
--- a/docs/SUPPORTED_NIPS.md
+++ b/docs/SUPPORTED_NIPS.md
@@ -77,6 +77,7 @@ Keep this file up to date whenever adding or removing support.
 | 73 | External content IDs | `~/code/nips/73.md` | `src/wrappers/nip73.ts` | `src/wrappers/nip73.test.ts` |
 | 96 | HTTP file storage | `~/code/nips/96.md` | `src/wrappers/nip96.ts` | `src/wrappers/nip96.test.ts` |
 | 35 | Torrents | `~/code/nips/35.md` | `src/wrappers/nip35.ts` | `src/wrappers/nip35.test.ts` |
+| 37 | Draft wraps | `~/code/nips/37.md` | `src/wrappers/nip37.ts` | `src/wrappers/nip37.test.ts` |
 
 Notes
 - Registry modules live under `src/relay/core/nip/modules/**`. Default relay modules: NIP-01, NIP-11, NIP-16/33. Others (e.g., NIP-28, NIP-57, NIP-42) are available but may not be in `DefaultModules`.

--- a/docs/UNSUPPORTED_NIPS.md
+++ b/docs/UNSUPPORTED_NIPS.md
@@ -11,7 +11,6 @@ Source of truth for supported NIPs: `docs/SUPPORTED_NIPS.md`.
 - 15 — `~/code/nips/15.md`
 - 22 — `~/code/nips/22.md`
 - 24 — `~/code/nips/24.md`
-- 37 — `~/code/nips/37.md`
 - 38 — `~/code/nips/38.md`
 - 55 — `~/code/nips/55.md`
 - 60 — `~/code/nips/60.md`

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "./nip72": "./src/wrappers/nip72.ts",
     "./nip84": "./src/wrappers/nip84.ts",
     "./nip35": "./src/wrappers/nip35.ts",
+    "./nip37": "./src/wrappers/nip37.ts",
     "./nip56": "./src/wrappers/nip56.ts",
     "./nip68": "./src/wrappers/nip68.ts",
     "./nip69": "./src/wrappers/nip69.ts",

--- a/src/wrappers/nip37.test.ts
+++ b/src/wrappers/nip37.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Tests for NIP-37 Draft Wraps
+ */
+import { describe, test, expect } from "bun:test"
+import { generateSecretKey, verifyEvent } from "./pure.js"
+import {
+  DraftWrapKind,
+  PrivateRelaysKind,
+  signDraftWrap,
+  decryptForAuthor,
+  signPrivateRelays,
+} from "./nip37.js"
+
+describe("NIP-37 Draft Wraps", () => {
+  test("build/sign draft wrap with encrypted content", () => {
+    const sk = generateSecretKey()
+    const draft = { kind: 1, content: "hello", tags: [] as string[][] }
+    const evt = signDraftWrap({ draft, draftKind: 1, identifier: "note-1", expiration: String(Math.floor(Date.now() / 1000) + 777_600) }, sk)
+    expect(evt.kind).toBe(DraftWrapKind)
+    const k = evt.tags.find((t) => t[0] === "k")
+    const d = evt.tags.find((t) => t[0] === "d")
+    expect(k?.[1]).toBe("1")
+    expect(d?.[1]).toBe("note-1")
+    expect(evt.content.length).toBeGreaterThan(0)
+    const plaintext = decryptForAuthor(evt.content, sk)
+    expect(() => JSON.parse(plaintext)).not.toThrow()
+    expect(verifyEvent(evt)).toBe(true)
+  })
+
+  test("build/sign private relays list with encrypted content", () => {
+    const sk = generateSecretKey()
+    const evt = signPrivateRelays({ relays: ["wss://a", "wss://b"] }, sk)
+    expect(evt.kind).toBe(PrivateRelaysKind)
+    expect(evt.tags.length).toBe(0)
+    const tupleJson = decryptForAuthor(evt.content, sk)
+    const tuples = JSON.parse(tupleJson) as string[][]
+    expect(Array.isArray(tuples)).toBe(true)
+    expect(tuples[0]?.[0]).toBe("relay")
+    expect(tuples[0]?.[1]).toBe("wss://a")
+    expect(verifyEvent(evt)).toBe(true)
+  })
+})

--- a/src/wrappers/nip37.ts
+++ b/src/wrappers/nip37.ts
@@ -1,0 +1,82 @@
+/**
+ * NIP-37: Draft Wraps
+ * Spec: ~/code/nips/37.md
+ */
+import type { Event, EventTemplate } from "./pure.js"
+import { finalizeEvent, getPublicKey } from "./pure.js"
+import { getConversationKey, encrypt, decrypt } from "./nip44.js"
+
+export const DraftWrapKind = 31234
+export const PrivateRelaysKind = 10013
+
+export interface DraftWrapParams {
+  readonly draft: Record<string, unknown>
+  readonly draftKind: number
+  readonly identifier?: string
+  readonly expiration?: string | number
+  readonly created_at?: number
+}
+
+/** Build a draft wrap template (kind 31234). Content is NIP-44 encrypted JSON of the draft event. */
+export function buildDraftWrap(p: DraftWrapParams, authorSecretKey: Uint8Array): EventTemplate {
+  const authorPub = getPublicKey(authorSecretKey)
+  const ck = getConversationKey(authorSecretKey, authorPub)
+  const plaintext = JSON.stringify(p.draft)
+  const ciphertext = encrypt(plaintext, ck)
+
+  const tags: string[][] = [["k", String(p.draftKind)]]
+  if (p.identifier) tags.push(["d", p.identifier])
+  if (p.expiration !== undefined) tags.push(["expiration", String(p.expiration)])
+
+  return {
+    kind: DraftWrapKind,
+    content: ciphertext,
+    tags,
+    created_at: p.created_at ?? Math.floor(Date.now() / 1000),
+  }
+}
+
+export function signDraftWrap(p: DraftWrapParams, authorSecretKey: Uint8Array): Event {
+  return finalizeEvent(buildDraftWrap(p, authorSecretKey), authorSecretKey)
+}
+
+/** Mark a draft wrap as deleted by blanking content (same tags). */
+export function buildDeletedDraft(identifier: string, draftKind: number, created_at?: number): EventTemplate {
+  return {
+    kind: DraftWrapKind,
+    content: "",
+    tags: [["d", identifier], ["k", String(draftKind)]],
+    created_at: created_at ?? Math.floor(Date.now() / 1000),
+  }
+}
+
+export interface PrivateRelaysParams {
+  readonly relays: readonly string[]
+  readonly created_at?: number
+}
+
+/** Build a Private Storage Relay list (kind 10013). Content is NIP-44 encrypted JSON array of ["relay", url] tuples. */
+export function buildPrivateRelays(p: PrivateRelaysParams, authorSecretKey: Uint8Array): EventTemplate {
+  const authorPub = getPublicKey(authorSecretKey)
+  const ck = getConversationKey(authorSecretKey, authorPub)
+  const tuples = p.relays.map((url) => ["relay", url])
+  const content = encrypt(JSON.stringify(tuples), ck)
+  return {
+    kind: PrivateRelaysKind,
+    content,
+    tags: [],
+    created_at: p.created_at ?? Math.floor(Date.now() / 1000),
+  }
+}
+
+export function signPrivateRelays(p: PrivateRelaysParams, authorSecretKey: Uint8Array): Event {
+  return finalizeEvent(buildPrivateRelays(p, authorSecretKey), authorSecretKey)
+}
+
+/** Helper to decrypt draft content (for testing/utilities) */
+export function decryptForAuthor(content: string, authorSecretKey: Uint8Array): string {
+  const authorPub = getPublicKey(authorSecretKey)
+  const ck = getConversationKey(authorSecretKey, authorPub)
+  return decrypt(content, ck)
+}
+


### PR DESCRIPTION
- Add wrappers/nip37.ts: build/sign draft wraps (31234) encrypted to author via NIP-44; build/sign private relay list (10013)
- Add tests: src/wrappers/nip37.test.ts encryption/decryption checks
- Update docs/SUPPORTED_NIPS.md and docs/UNSUPPORTED_NIPS.md; export nip37 in package.json

All changes pass `bun run verify`.