### PR TITLE
feat(nip15): Nostr Marketplace builders + tests

### DIFF
--- a/docs/SUPPORTED_NIPS.md
+++ b/docs/SUPPORTED_NIPS.md
@@ -22,6 +22,7 @@ Keep this file up to date whenever adding or removing support.
 | 11 | Relay information | `~/code/nips/11.md` | `src/relay/core/nip/modules/Nip11Module.ts` | `src/core/Nip11.test.ts`, `src/relay/RelayInfo.test.ts` |
 | 13 | Proof of Work | `~/code/nips/13.md` | `src/wrappers/nip13.ts` | `src/core/Nip13.test.ts` |
 | 14 | Subject tag | `~/code/nips/14.md` | `src/wrappers/nip14.ts` | `src/wrappers/nip14.test.ts` |
+| 15 | Nostr Marketplace | `~/code/nips/15.md` | `src/wrappers/nip15.ts` | `src/wrappers/nip15.test.ts` |
 | 16 | Event treatment | `~/code/nips/16.md` | `src/relay/core/nip/modules/Nip16Module.ts` | `src/relay/core/nip/NipRegistry.test.ts` |
 | 17 | Private direct messages | `~/code/nips/17.md` | `src/client/Nip17Service.ts` | `src/core/Nip17.test.ts`, `src/client/Nip17Service.test.ts` |
 | 18 | Reposts | `~/code/nips/18.md` | `src/client/Nip18Service.ts` | `src/client/Nip18Service.test.ts` |

--- a/docs/UNSUPPORTED_NIPS.md
+++ b/docs/UNSUPPORTED_NIPS.md
@@ -7,7 +7,7 @@ Source of truth for supported NIPs: `docs/SUPPORTED_NIPS.md`.
 - ~~07 — `~/code/nips/07.md`~~
 - ~~08 — `~/code/nips/08.md`~~
 - 12 — `~/code/nips/12.md`
-- 15 — `~/code/nips/15.md`
+- ~~15 — `~/code/nips/15.md`~~
 - ~~22 — `~/code/nips/22.md`~~
 - 24 — `~/code/nips/24.md`
 - 38 — `~/code/nips/38.md`

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "./nip22": "./src/wrappers/nip22.ts",
     "./nip11": "./src/wrappers/nip11.ts",
     "./nip13": "./src/wrappers/nip13.ts",
+    "./nip15": "./src/wrappers/nip15.ts",
     "./nip17": "./src/wrappers/nip17.ts",
     "./nip18": "./src/wrappers/nip18.ts",
     "./nip19": "./src/wrappers/nip19.ts",

--- a/src/wrappers/nip15.test.ts
+++ b/src/wrappers/nip15.test.ts
@@ -1,0 +1,109 @@
+/**
+ * Tests for NIP-15 Nostr Marketplace
+ */
+import { describe, test, expect } from "bun:test"
+import { generateSecretKey, verifyEvent } from "./pure.js"
+import {
+  StallKind,
+  ProductKind,
+  MarketUIKind,
+  AuctionKind,
+  BidKind,
+  BidConfirmationKind,
+  signStallEvent,
+  signProductEvent,
+  signMarketUIEvent,
+  signAuctionEvent,
+  signBidEvent,
+  signBidConfirmationEvent,
+} from "./nip15.js"
+
+describe("NIP-15: Marketplace", () => {
+  test("stall (30017) has d tag equal to id", () => {
+    const sk = generateSecretKey()
+    const stall = signStallEvent({
+      id: "stall-abc",
+      name: "My Stall",
+      currency: "USD",
+      shipping: [{ id: "zone-us", name: "US", cost: 10, regions: ["US"] }],
+    }, sk)
+    expect(stall.kind).toBe(StallKind)
+    expect(verifyEvent(stall)).toBe(true)
+    const d = stall.tags.find((t) => t[0] === "d")
+    expect(d?.[1]).toBe("stall-abc")
+  })
+
+  test("product (30018) includes categories and d tag", () => {
+    const sk = generateSecretKey()
+    const product = signProductEvent({
+      id: "prod-xyz",
+      stall_id: "stall-abc",
+      name: "Gadget",
+      currency: "USD",
+      price: 199.99,
+      quantity: 5,
+    }, sk, { categories: ["electronics", "gadgets"] })
+    expect(product.kind).toBe(ProductKind)
+    expect(verifyEvent(product)).toBe(true)
+    const d = product.tags.find((t) => t[0] === "d")
+    const ts = product.tags.filter((t) => t[0] === "t").map((t) => t[1])
+    expect(d?.[1]).toBe("prod-xyz")
+    expect(ts).toContain("electronics")
+    expect(ts).toContain("gadgets")
+  })
+
+  test("market UI (30019) content JSON", () => {
+    const sk = generateSecretKey()
+    const evt = signMarketUIEvent({
+      name: "Cool Market",
+      about: "A curated bazaar",
+      ui: { picture: "https://pic/logo.png", theme: "classic", darkMode: true },
+      merchants: ["a".repeat(64), "b".repeat(64)],
+    }, sk)
+    expect(evt.kind).toBe(MarketUIKind)
+    expect(verifyEvent(evt)).toBe(true)
+    expect(() => JSON.parse(evt.content)).not.toThrow()
+  })
+
+  test("auction (30020) and bid (1021) + bid confirmation (1022)", () => {
+    const skMerchant = generateSecretKey()
+    const skBidder = generateSecretKey()
+
+    const auction = signAuctionEvent({
+      id: "auc-1",
+      stall_id: "stall-abc",
+      name: "Rare Artifact",
+      starting_bid: 10000,
+      duration: 3600,
+    }, skMerchant, { categories: ["collectibles"] })
+
+    expect(auction.kind).toBe(AuctionKind)
+    const d = auction.tags.find((t) => t[0] === "d")
+    expect(d?.[1]).toBe("auc-1")
+
+    const bid = signBidEvent({ auctionEventId: auction.id, amount: 15000 }, skBidder)
+    expect(bid.kind).toBe(BidKind)
+    expect(bid.content).toBe("15000")
+    const e = bid.tags.find((t) => t[0] === "e")
+    expect(e?.[1]).toBe(auction.id)
+
+    const confirm = signBidConfirmationEvent({
+      bidEventId: bid.id,
+      auctionEventId: auction.id,
+      content: { status: "accepted", duration_extended: 120 },
+    }, skMerchant)
+
+    expect(confirm.kind).toBe(BidConfirmationKind)
+    const es = confirm.tags.filter((t) => t[0] === "e").map((t) => t[1])
+    expect(es).toContain(bid.id)
+    expect(es).toContain(auction.id)
+    const parsed = JSON.parse(confirm.content)
+    expect(parsed.status).toBe("accepted")
+    expect(parsed.duration_extended).toBe(120)
+
+    expect(verifyEvent(auction)).toBe(true)
+    expect(verifyEvent(bid)).toBe(true)
+    expect(verifyEvent(confirm)).toBe(true)
+  })
+})
+

--- a/src/wrappers/nip15.ts
+++ b/src/wrappers/nip15.ts
@@ -1,0 +1,196 @@
+/**
+ * NIP-15: Nostr Marketplace
+ * Spec: ~/code/nips/15.md
+ */
+import type { Event, EventTemplate } from "./pure.js"
+import { finalizeEvent } from "./pure.js"
+
+// Kinds
+export const StallKind = 30017
+export const ProductKind = 30018
+export const MarketUIKind = 30019
+export const AuctionKind = 30020
+export const BidKind = 1021
+export const BidConfirmationKind = 1022
+
+// =============================================================================
+// Types (content payloads per NIP-15)
+// =============================================================================
+
+export interface StallShippingZone {
+  readonly id: string
+  readonly name?: string
+  readonly cost: number
+  readonly regions: readonly string[]
+}
+
+export interface StallContent {
+  readonly id: string
+  readonly name: string
+  readonly description?: string
+  readonly currency: string
+  readonly shipping: readonly StallShippingZone[]
+}
+
+export interface ProductSpecKV extends Array<string> {
+  0: string
+  1: string
+}
+
+export interface ProductShippingExtra {
+  readonly id: string
+  readonly cost: number
+}
+
+export interface ProductContent {
+  readonly id: string
+  readonly stall_id: string
+  readonly name: string
+  readonly description?: string
+  readonly images?: readonly string[]
+  readonly currency: string
+  readonly price: number
+  readonly quantity: number | null
+  readonly specs?: readonly ProductSpecKV[]
+  readonly shipping?: readonly ProductShippingExtra[]
+}
+
+export interface MarketUIContent {
+  readonly name?: string
+  readonly about?: string
+  readonly ui?: {
+    readonly picture?: string
+    readonly banner?: string
+    readonly theme?: string
+    readonly darkMode?: boolean
+  }
+  readonly merchants?: readonly string[]
+}
+
+export interface AuctionContent {
+  readonly id: string
+  readonly stall_id: string
+  readonly name: string
+  readonly description?: string
+  readonly images?: readonly string[]
+  readonly starting_bid: number
+  readonly start_date?: number
+  readonly duration: number
+  readonly specs?: readonly ProductSpecKV[]
+  readonly shipping?: readonly ProductShippingExtra[]
+}
+
+export type BidStatus = "accepted" | "rejected" | "pending" | "winner"
+
+export interface BidConfirmationContent {
+  readonly status: BidStatus
+  readonly message?: string
+  readonly duration_extended?: number
+}
+
+// =============================================================================
+// Builders
+// =============================================================================
+
+const now = () => Math.floor(Date.now() / 1000)
+
+export function buildStallEvent(
+  content: StallContent,
+  options?: { created_at?: number }
+): EventTemplate {
+  const tags: string[][] = [["d", content.id]]
+  return {
+    kind: StallKind,
+    content: JSON.stringify(content),
+    tags,
+    created_at: options?.created_at ?? now(),
+  }
+}
+
+export function signStallEvent(content: StallContent, sk: Uint8Array, opts?: { created_at?: number }): Event {
+  return finalizeEvent(buildStallEvent(content, opts), sk)
+}
+
+export function buildProductEvent(
+  content: ProductContent,
+  options?: { categories?: readonly string[]; created_at?: number }
+): EventTemplate {
+  const tags: string[][] = [["d", content.id]]
+  if (options?.categories) for (const cat of options.categories) tags.push(["t", cat])
+  return {
+    kind: ProductKind,
+    content: JSON.stringify(content),
+    tags,
+    created_at: options?.created_at ?? now(),
+  }
+}
+
+export function signProductEvent(content: ProductContent, sk: Uint8Array, opts?: { categories?: readonly string[]; created_at?: number }): Event {
+  return finalizeEvent(buildProductEvent(content, opts), sk)
+}
+
+export function buildMarketUIEvent(content: MarketUIContent, options?: { created_at?: number }): EventTemplate {
+  return {
+    kind: MarketUIKind,
+    content: JSON.stringify(content),
+    tags: [],
+    created_at: options?.created_at ?? now(),
+  }
+}
+
+export function signMarketUIEvent(content: MarketUIContent, sk: Uint8Array, opts?: { created_at?: number }): Event {
+  return finalizeEvent(buildMarketUIEvent(content, opts), sk)
+}
+
+export function buildAuctionEvent(
+  content: AuctionContent,
+  options?: { categories?: readonly string[]; created_at?: number }
+): EventTemplate {
+  const tags: string[][] = [["d", content.id]]
+  if (options?.categories) for (const cat of options.categories) tags.push(["t", cat])
+  return {
+    kind: AuctionKind,
+    content: JSON.stringify(content),
+    tags,
+    created_at: options?.created_at ?? now(),
+  }
+}
+
+export function signAuctionEvent(content: AuctionContent, sk: Uint8Array, opts?: { categories?: readonly string[]; created_at?: number }): Event {
+  return finalizeEvent(buildAuctionEvent(content, opts), sk)
+}
+
+export function buildBidEvent(params: { auctionEventId: string; amount: number; created_at?: number }): EventTemplate {
+  return {
+    kind: BidKind,
+    content: String(params.amount),
+    tags: [["e", params.auctionEventId]],
+    created_at: params.created_at ?? now(),
+  }
+}
+
+export function signBidEvent(params: { auctionEventId: string; amount: number; created_at?: number }, sk: Uint8Array): Event {
+  return finalizeEvent(buildBidEvent(params), sk)
+}
+
+export function buildBidConfirmationEvent(params: {
+  bidEventId: string
+  auctionEventId: string
+  content: BidConfirmationContent
+  created_at?: number
+}): EventTemplate {
+  return {
+    kind: BidConfirmationKind,
+    content: JSON.stringify(params.content),
+    tags: [["e", params.bidEventId], ["e", params.auctionEventId]],
+    created_at: params.created_at ?? now(),
+  }
+}
+
+export function signBidConfirmationEvent(
+  params: { bidEventId: string; auctionEventId: string; content: BidConfirmationContent; created_at?: number },
+  sk: Uint8Array
+): Event {
+  return finalizeEvent(buildBidConfirmationEvent(params), sk)
+}
+


### PR DESCRIPTION
Implements NIP-15 Nostr Marketplace.\n\n- Builders:\n  - Stall (30017) with required d tag\n  - Product (30018) with d tag and optional categories (t tags)\n  - Marketplace UI/UX (30019) content JSON\n  - Auction Product (30020) with d tag and optional categories\n  - Bid (1021) referencing auction via e tag\n  - Bid Confirmation (1022) with two e tags (bid + auction) and JSON content\n- Tests: src/wrappers/nip15.test.ts\n- Exports: add ./nip15 to package.json\n- Docs: add NIP-15 to docs/SUPPORTED_NIPS.md (sorted), remove from docs/UNSUPPORTED_NIPS.md\n\n'bun run verify' passes (tsc + tests).