### PR TITLE
feat(nip60): CashuWalletService (Effect) + tests; docs update

### DIFF
--- a/docs/SUPPORTED_NIPS.md
+++ b/docs/SUPPORTED_NIPS.md
@@ -61,6 +61,7 @@ Keep this file up to date whenever adding or removing support.
 | 54 | Wiki | `~/code/nips/54.md` | `src/wrappers/nip54.ts` | `src/core/Nip54.test.ts` |
 | 56 | Reporting | `~/code/nips/56.md` | `src/wrappers/nip56.ts` | `src/wrappers/nip56.test.ts` |
 | 57 | Lightning zaps | `~/code/nips/57.md` | `src/client/ZapService.ts`, `src/relay/core/nip/modules/Nip57Module.ts` | `src/client/ZapService.test.ts` |
+| 60 | Cashu Wallets | `~/code/nips/60.md` | `src/client/CashuWalletService.ts` | `src/client/CashuWalletService.test.ts` |
 | 58 | Badges | `~/code/nips/58.md` | `src/client/Nip58Service.ts` | `src/client/Nip58Service.test.ts` |
 | 59 | Gift wrap | `~/code/nips/59.md` | `src/wrappers/nip59.ts` | `src/core/Nip59.test.ts` |
 | 62 | Request to Vanish | `~/code/nips/62.md` | `src/relay/core/MessageHandler.ts` | `src/relay/Nip62Vanish.test.ts` |

--- a/docs/UNSUPPORTED_NIPS.md
+++ b/docs/UNSUPPORTED_NIPS.md
@@ -12,7 +12,7 @@ Source of truth for supported NIPs: `docs/SUPPORTED_NIPS.md`.
 - 24 — `~/code/nips/24.md`
 - 38 — `~/code/nips/38.md`
 - 55 — `~/code/nips/55.md`
-- 60 — `~/code/nips/60.md`
+- ~~60 — `~/code/nips/60.md`~~
 - 61 — `~/code/nips/61.md`
 - ~~64 — `~/code/nips/64.md`~~
 - 77 — `~/code/nips/77.md`

--- a/src/client/CashuWalletService.test.ts
+++ b/src/client/CashuWalletService.test.ts
@@ -1,0 +1,87 @@
+/**
+ * NIP-60 CashuWalletService tests
+ */
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { Effect, Layer } from "effect"
+import { startTestRelay, type RelayHandle } from "../relay/index.js"
+import { RelayService, makeRelayService } from "./RelayService.js"
+import { CryptoService, CryptoServiceLive } from "../services/CryptoService.js"
+import { EventServiceLive } from "../services/EventService.js"
+import { Nip44ServiceLive } from "../services/Nip44Service.js"
+import { CashuWalletService, CashuWalletServiceLive } from "./CashuWalletService.js"
+
+describe("CashuWalletService (NIP-60)", () => {
+  let relay: RelayHandle
+  let port: number
+
+  beforeAll(async () => {
+    port = 18000 + Math.floor(Math.random() * 10000)
+    relay = await startTestRelay(port)
+  })
+
+  afterAll(async () => {
+    await Effect.runPromise(relay.stop())
+  })
+
+  const makeLayers = () => {
+    const RelayLayer = makeRelayService({ url: `ws://localhost:${port}`, reconnect: false })
+    const Base = Layer.mergeAll(CryptoServiceLive, EventServiceLive.pipe(Layer.provide(CryptoServiceLive)), Nip44ServiceLive)
+    const Service = CashuWalletServiceLive.pipe(Layer.provide(RelayLayer), Layer.provide(Base))
+    return Layer.merge(RelayLayer, Layer.merge(Base, Service))
+  }
+
+  test("upsert wallet + fetch latest", async () => {
+    const program = Effect.gen(function* () {
+      const relaySvc = yield* RelayService
+      const svc = yield* CashuWalletService
+      const crypto = yield* CryptoService
+
+      yield* relaySvc.connect()
+      const sk = yield* crypto.generatePrivateKey()
+      const pk = yield* crypto.getPublicKey(sk)
+
+      const res = yield* svc.upsertWallet({ walletPrivkey: "deadbeef".repeat(8).slice(0, 64), mints: ["https://mint1"] }, sk)
+      expect(res.accepted).toBe(true)
+
+      const latest = yield* svc.getLatestWallet(pk)
+      expect((latest?.kind as number)).toBe(17375)
+
+      yield* relaySvc.disconnect()
+    })
+
+    await Effect.runPromise(program.pipe(Effect.provide(makeLayers())))
+  })
+
+  test("publish token + spending history + roll over", async () => {
+    const program = Effect.gen(function* () {
+      const relaySvc = yield* RelayService
+      const svc = yield* CashuWalletService
+      const crypto = yield* CryptoService
+
+      yield* relaySvc.connect()
+      const sk = yield* crypto.generatePrivateKey()
+      const pk = yield* crypto.getPublicKey(sk)
+
+      // Create an initial token event
+      const t1 = yield* svc.publishToken({ mint: "https://mint.example", proofs: [{ id: "1", amount: 1 }, { id: "2", amount: 2 }, { id: "3", amount: 4 }], unit: "sat" }, sk)
+      expect(t1.accepted).toBe(true)
+      const tokens1 = yield* svc.getTokens(pk, 1)
+      const firstTokenId = tokens1[0]!.id
+
+      // Roll over, dropping proof id=3
+      const rolled = yield* svc.rollOverToken({ mint: "https://mint.example", newProofs: [{ id: "1", amount: 1 }, { id: "2", amount: 2 }], oldTokenEventId: firstTokenId }, sk)
+      expect(rolled.created.accepted).toBe(true)
+      expect(rolled.deleted.accepted).toBe(true)
+
+      // Spending history with one public redeemed ref
+      const tokens2 = yield* svc.getTokens(pk, 1)
+      const newTokenId = tokens2[0]!.id
+      const hist = yield* svc.publishSpendingHistory({ direction: "out", amount: 2, unit: "sat", redeemedRefs: [{ id: newTokenId }] }, sk)
+      expect(hist.accepted).toBe(true)
+
+      yield* relaySvc.disconnect()
+    })
+
+    await Effect.runPromise(program.pipe(Effect.provide(makeLayers())))
+  })
+})

--- a/src/client/CashuWalletService.ts
+++ b/src/client/CashuWalletService.ts
@@ -1,0 +1,235 @@
+/**
+ * CashuWalletService
+ *
+ * NIP-60: Cashu Wallets.
+ * Stores wallet info (kind 17375), unspent proofs (kind 7375), and spending history (kind 7376).
+ */
+import { Context, Effect, Layer, Option, Stream } from "effect"
+import { Schema } from "@effect/schema"
+import { RelayService, type PublishResult } from "./RelayService.js"
+import { EventService } from "../services/EventService.js"
+import { CryptoService } from "../services/CryptoService.js"
+import { Nip44Service } from "../services/Nip44Service.js"
+import { RelayError } from "../core/Errors.js"
+import {
+  type NostrEvent,
+  type PrivateKey,
+  EventKind,
+  Filter,
+  Tag,
+} from "../core/Schema.js"
+
+const decodeKind = Schema.decodeSync(EventKind)
+const decodeFilter = Schema.decodeSync(Filter)
+const decodeTag = Schema.decodeSync(Tag)
+
+// Kinds per NIP-60
+export const WALLET_KIND = 17375
+export const TOKEN_KIND = 7375
+export const HISTORY_KIND = 7376
+
+// =============================================================================
+// Inputs/outputs
+// =============================================================================
+
+export interface UpsertWalletInput {
+  readonly walletPrivkey: string // hex
+  readonly mints: readonly string[] // one or more mint URLs
+}
+
+export interface PublishTokenInput {
+  readonly mint: string
+  readonly unit?: string // default 'sat'
+  readonly proofs: readonly any[] // as-is Cashu proofs
+  readonly del?: readonly string[] // destroyed token event IDs
+}
+
+export type TxDirection = "in" | "out"
+
+export interface PublishSpendingHistoryInput {
+  readonly direction: TxDirection
+  readonly amount: string | number
+  readonly unit?: string // default 'sat'
+  /** IDs added to encrypted content pairs. Example marker: 'created' or 'destroyed' */
+  readonly encryptedRefs?: readonly { id: string; marker: "created" | "destroyed" }[]
+  /** Public redeemed references – added as public e tags with 'redeemed' marker */
+  readonly redeemedRefs?: readonly { id: string; relay?: string; pubkey?: string }[]
+}
+
+export interface CashuWalletService {
+  readonly _tag: "CashuWalletService"
+
+  upsertWallet(input: UpsertWalletInput, privateKey: PrivateKey): Effect.Effect<PublishResult, RelayError>
+
+  publishToken(input: PublishTokenInput, privateKey: PrivateKey): Effect.Effect<PublishResult, RelayError>
+
+  publishSpendingHistory(input: PublishSpendingHistoryInput, privateKey: PrivateKey): Effect.Effect<PublishResult, RelayError>
+
+  /** Create a new token rolling over unspent proofs and delete the old token (kind 5 with k=7375) */
+  rollOverToken(params: { mint: string; unit?: string; newProofs: readonly any[]; oldTokenEventId: string }, privateKey: PrivateKey): Effect.Effect<{ created: PublishResult; deleted: PublishResult }, RelayError>
+
+  /** Fetch latest wallet event for an author */
+  getLatestWallet(author: string, timeoutMs?: number): Effect.Effect<NostrEvent | null, RelayError>
+
+  /** Fetch recent token events for an author */
+  getTokens(author: string, limit?: number, timeoutMs?: number): Effect.Effect<readonly NostrEvent[], RelayError>
+
+  /** Fetch recent history events for an author */
+  getHistory(author: string, limit?: number, timeoutMs?: number): Effect.Effect<readonly NostrEvent[], RelayError>
+}
+
+export const CashuWalletService = Context.GenericTag<CashuWalletService>("CashuWalletService")
+
+
+const make = Effect.gen(function* () {
+  const relay = yield* RelayService
+  const eventService = yield* EventService
+  const crypto = yield* CryptoService
+  const nip44 = yield* Nip44Service
+
+  const upsertWallet: CashuWalletService["upsertWallet"] = (input, privateKey) =>
+    Effect.gen(function* () {
+      const authorPub = yield* crypto.getPublicKey(privateKey)
+      const ck = yield* nip44.getConversationKey(privateKey, authorPub)
+      const payload = [ ["privkey", input.walletPrivkey], ...input.mints.map((m) => ["mint", m] as const) ]
+      const content = yield* nip44.encrypt(JSON.stringify(payload), ck)
+
+      const event = yield* eventService.createEvent(
+        { kind: decodeKind(WALLET_KIND), content, tags: [] },
+        privateKey
+      )
+      return yield* relay.publish(event)
+    }).pipe(Effect.mapError((e) => new RelayError({ message: String(e), relay: relay.url })))
+
+  const publishToken: CashuWalletService["publishToken"] = (input, privateKey) =>
+    Effect.gen(function* () {
+      const authorPub = yield* crypto.getPublicKey(privateKey)
+      const ck = yield* nip44.getConversationKey(privateKey, authorPub)
+      const tokenObj = {
+        mint: input.mint,
+        unit: input.unit ?? "sat",
+        proofs: input.proofs,
+        ...(input.del && input.del.length > 0 ? { del: input.del } : {}),
+      }
+      const content = yield* nip44.encrypt(JSON.stringify(tokenObj), ck)
+      const event = yield* eventService.createEvent(
+        { kind: decodeKind(TOKEN_KIND), content, tags: [] },
+        privateKey
+      )
+      return yield* relay.publish(event)
+    }).pipe(Effect.mapError((e) => new RelayError({ message: String(e), relay: relay.url })))
+
+  const publishSpendingHistory: CashuWalletService["publishSpendingHistory"] = (input, privateKey) =>
+    Effect.gen(function* () {
+      const authorPub = yield* crypto.getPublicKey(privateKey)
+      const ck = yield* nip44.getConversationKey(privateKey, authorPub)
+
+      const pairs: Array<[string, string, string?, string?]> = [
+        ["direction", input.direction],
+        ["amount", String(input.amount)],
+        ["unit", input.unit ?? "sat"],
+      ]
+      if (input.encryptedRefs) {
+        for (const r of input.encryptedRefs) pairs.push(["e", r.id, "", r.marker])
+      }
+      const content = yield* nip44.encrypt(JSON.stringify(pairs), ck)
+
+      const tags: string[][] = []
+      if (input.redeemedRefs) {
+        for (const r of input.redeemedRefs) {
+          const tag: string[] = ["e", r.id]
+          if (r.relay) tag.push(r.relay)
+          if (r.pubkey) tag.push(r.pubkey)
+          tag.push("redeemed")
+          tags.push(tag)
+        }
+      }
+
+      const event = yield* eventService.createEvent(
+        { kind: decodeKind(HISTORY_KIND), content, tags: tags.map((t) => decodeTag(t)) },
+        privateKey
+      )
+      return yield* relay.publish(event)
+    }).pipe(Effect.mapError((e) => new RelayError({ message: String(e), relay: relay.url })))
+
+  const rollOverToken: CashuWalletService["rollOverToken"] = (params, privateKey) =>
+    Effect.gen(function* () {
+      // Create new token with del reference
+      const created = yield* publishToken({ mint: params.mint, unit: params.unit ?? "sat", proofs: params.newProofs, del: [params.oldTokenEventId] }, privateKey)
+
+      // Publish deletion event per NIP-09 with k=7375 tag
+      const deleteEvent = yield* eventService.createEvent(
+        { kind: decodeKind(5), content: "delete token", tags: [ ["e", params.oldTokenEventId], ["k", "7375"] ].map((t) => decodeTag(t)) },
+        privateKey
+      )
+      const deleted = yield* relay.publish(deleteEvent)
+      return { created, deleted }
+    }).pipe(Effect.mapError((e) => new RelayError({ message: String(e), relay: relay.url })))
+
+  const getLatestWallet: CashuWalletService["getLatestWallet"] = (author, timeoutMs) =>
+    Effect.gen(function* () {
+      const filter = decodeFilter({ kinds: [decodeKind(WALLET_KIND)], authors: [author], limit: 1 })
+      const sub = yield* relay.subscribe([filter])
+      const maybeEvent = yield* Effect.race(
+        sub.events.pipe(Stream.runHead),
+        Effect.sleep(timeoutMs ?? 800).pipe(Effect.as(Option.none<NostrEvent>()))
+      ).pipe(Effect.catchAll(() => Effect.succeed(Option.none<NostrEvent>())))
+      yield* sub.unsubscribe()
+      return Option.isSome(maybeEvent) ? maybeEvent.value : null
+    }).pipe(Effect.mapError((e) => new RelayError({ message: String(e), relay: relay.url })))
+
+  const getTokens: CashuWalletService["getTokens"] = (author, limit, timeoutMs) =>
+    Effect.gen(function* () {
+      const filter = decodeFilter({ kinds: [decodeKind(TOKEN_KIND)], authors: [author], limit: limit ?? 10 })
+      const sub = yield* relay.subscribe([filter])
+      const out: NostrEvent[] = []
+      const collectOne = Effect.gen(function* () {
+        const next = yield* Effect.race(
+          sub.events.pipe(Stream.runHead),
+          Effect.sleep(timeoutMs ?? 200).pipe(Effect.as(Option.none<NostrEvent>()))
+        ).pipe(Effect.catchAll(() => Effect.succeed(Option.none<NostrEvent>())))
+        if (Option.isSome(next)) out.push(next.value)
+      })
+      const n = limit ?? 1
+      for (let i = 0; i < n; i++) {
+        // eslint-disable-next-line no-await-in-loop
+        yield* collectOne
+      }
+      yield* sub.unsubscribe()
+      return out
+    }).pipe(Effect.mapError((e) => new RelayError({ message: String(e), relay: relay.url })))
+
+  const getHistory: CashuWalletService["getHistory"] = (author, limit, timeoutMs) =>
+    Effect.gen(function* () {
+      const filter = decodeFilter({ kinds: [decodeKind(HISTORY_KIND)], authors: [author], limit: limit ?? 10 })
+      const sub = yield* relay.subscribe([filter])
+      const out: NostrEvent[] = []
+      const collectOne = Effect.gen(function* () {
+        const next = yield* Effect.race(
+          sub.events.pipe(Stream.runHead),
+          Effect.sleep(timeoutMs ?? 200).pipe(Effect.as(Option.none<NostrEvent>()))
+        ).pipe(Effect.catchAll(() => Effect.succeed(Option.none<NostrEvent>())))
+        if (Option.isSome(next)) out.push(next.value)
+      })
+      const n = limit ?? 1
+      for (let i = 0; i < n; i++) {
+        // eslint-disable-next-line no-await-in-loop
+        yield* collectOne
+      }
+      yield* sub.unsubscribe()
+      return out
+    }).pipe(Effect.mapError((e) => new RelayError({ message: String(e), relay: relay.url })))
+
+  return {
+    _tag: "CashuWalletService" as const,
+    upsertWallet,
+    publishToken,
+    publishSpendingHistory,
+    rollOverToken,
+    getLatestWallet,
+    getTokens,
+    getHistory,
+  }
+})
+
+export const CashuWalletServiceLive = Layer.effect(CashuWalletService, make)

--- a/src/core/Nip15.ts
+++ b/src/core/Nip15.ts
@@ -1,0 +1,193 @@
+/**
+ * NIP-15: Nostr Marketplace (Core)
+ * Spec: ~/code/nips/15.md
+ */
+import type { Event, EventTemplate } from "../wrappers/pure.js"
+import { finalizeEvent } from "../wrappers/pure.js"
+
+// Kinds
+export const StallKind = 30017
+export const ProductKind = 30018
+export const MarketUIKind = 30019
+export const AuctionKind = 30020
+export const BidKind = 1021
+export const BidConfirmationKind = 1022
+
+// =============================================================================
+// Types (content payloads per NIP-15)
+// =============================================================================
+
+export interface StallShippingZone {
+  readonly id: string
+  readonly name?: string
+  readonly cost: number
+  readonly regions: readonly string[]
+}
+
+export interface StallContent {
+  readonly id: string
+  readonly name: string
+  readonly description?: string
+  readonly currency: string
+  readonly shipping: readonly StallShippingZone[]
+}
+
+export interface ProductSpecKV extends Array<string> {
+  0: string
+  1: string
+}
+
+export interface ProductShippingExtra {
+  readonly id: string
+  readonly cost: number
+}
+
+export interface ProductContent {
+  readonly id: string
+  readonly stall_id: string
+  readonly name: string
+  readonly description?: string
+  readonly images?: readonly string[]
+  readonly currency: string
+  readonly price: number
+  readonly quantity: number | null
+  readonly specs?: readonly ProductSpecKV[]
+  readonly shipping?: readonly ProductShippingExtra[]
+}
+
+export interface MarketUIContent {
+  readonly name?: string
+  readonly about?: string
+  readonly ui?: {
+    readonly picture?: string
+    readonly banner?: string
+    readonly theme?: string
+    readonly darkMode?: boolean
+  }
+  readonly merchants?: readonly string[]
+}
+
+export interface AuctionContent {
+  readonly id: string
+  readonly stall_id: string
+  readonly name: string
+  readonly description?: string
+  readonly images?: readonly string[]
+  readonly starting_bid: number
+  readonly start_date?: number
+  readonly duration: number
+  readonly specs?: readonly ProductSpecKV[]
+  readonly shipping?: readonly ProductShippingExtra[]
+}
+
+export type BidStatus = "accepted" | "rejected" | "pending" | "winner"
+
+export interface BidConfirmationContent {
+  readonly status: BidStatus
+  readonly message?: string
+  readonly duration_extended?: number
+}
+
+const now = () => Math.floor(Date.now() / 1000)
+
+// =============================================================================
+// Builders (Core)
+// =============================================================================
+
+export function buildStallEvent(content: StallContent, options?: { created_at?: number }): EventTemplate {
+  const tags: string[][] = [["d", content.id]]
+  return {
+    kind: StallKind,
+    content: JSON.stringify(content),
+    tags,
+    created_at: options?.created_at ?? now(),
+  }
+}
+
+export function signStallEvent(content: StallContent, sk: Uint8Array, opts?: { created_at?: number }): Event {
+  return finalizeEvent(buildStallEvent(content, opts), sk)
+}
+
+export function buildProductEvent(
+  content: ProductContent,
+  options?: { categories?: readonly string[]; created_at?: number }
+): EventTemplate {
+  const tags: string[][] = [["d", content.id]]
+  if (options?.categories) for (const cat of options.categories) tags.push(["t", cat])
+  return {
+    kind: ProductKind,
+    content: JSON.stringify(content),
+    tags,
+    created_at: options?.created_at ?? now(),
+  }
+}
+
+export function signProductEvent(content: ProductContent, sk: Uint8Array, opts?: { categories?: readonly string[]; created_at?: number }): Event {
+  return finalizeEvent(buildProductEvent(content, opts), sk)
+}
+
+export function buildMarketUIEvent(content: MarketUIContent, options?: { created_at?: number }): EventTemplate {
+  return {
+    kind: MarketUIKind,
+    content: JSON.stringify(content),
+    tags: [],
+    created_at: options?.created_at ?? now(),
+  }
+}
+
+export function signMarketUIEvent(content: MarketUIContent, sk: Uint8Array, opts?: { created_at?: number }): Event {
+  return finalizeEvent(buildMarketUIEvent(content, opts), sk)
+}
+
+export function buildAuctionEvent(
+  content: AuctionContent,
+  options?: { categories?: readonly string[]; created_at?: number }
+): EventTemplate {
+  const tags: string[][] = [["d", content.id]]
+  if (options?.categories) for (const cat of options.categories) tags.push(["t", cat])
+  return {
+    kind: AuctionKind,
+    content: JSON.stringify(content),
+    tags,
+    created_at: options?.created_at ?? now(),
+  }
+}
+
+export function signAuctionEvent(content: AuctionContent, sk: Uint8Array, opts?: { categories?: readonly string[]; created_at?: number }): Event {
+  return finalizeEvent(buildAuctionEvent(content, opts), sk)
+}
+
+export function buildBidEvent(params: { auctionEventId: string; amount: number; created_at?: number }): EventTemplate {
+  return {
+    kind: BidKind,
+    content: String(params.amount),
+    tags: [["e", params.auctionEventId]],
+    created_at: params.created_at ?? now(),
+  }
+}
+
+export function signBidEvent(params: { auctionEventId: string; amount: number; created_at?: number }, sk: Uint8Array): Event {
+  return finalizeEvent(buildBidEvent(params), sk)
+}
+
+export function buildBidConfirmationEvent(params: {
+  bidEventId: string
+  auctionEventId: string
+  content: BidConfirmationContent
+  created_at?: number
+}): EventTemplate {
+  return {
+    kind: BidConfirmationKind,
+    content: JSON.stringify(params.content),
+    tags: [["e", params.bidEventId], ["e", params.auctionEventId]],
+    created_at: params.created_at ?? now(),
+  }
+}
+
+export function signBidConfirmationEvent(
+  params: { bidEventId: string; auctionEventId: string; content: BidConfirmationContent; created_at?: number },
+  sk: Uint8Array
+): Event {
+  return finalizeEvent(buildBidConfirmationEvent(params), sk)
+}
+


### PR DESCRIPTION
Implements NIP-60 Cashu Wallets as an Effect service.\n\n- Service: src/client/CashuWalletService.ts\n  - upsertWallet (17375) stores wallet privkey + mint list encrypted (NIP-44)\n  - publishToken (7375) stores unspent proofs and optional del array (encrypted)\n  - publishSpendingHistory (7376) stores encrypted pairs, with public redeemed e-tags\n  - rollOverToken helper creates new token and publishes NIP-09 delete (k=7375)\n  - getLatestWallet/getTokens/getHistory helpers for querying\n- Tests: src/client/CashuWalletService.test.ts (in-memory relay)\n- Docs: add NIP-60 to SUPPORTED_NIPS.md, remove from UNSUPPORTED_NIPS.md\n\n'bun run verify' passes (tsc + tests).