### PR TITLE
feat(nip86): Relay Management API (NIP-86) + module + tests

### DIFF
--- a/docs/BUILDOUT.md
+++ b/docs/BUILDOUT.md
@@ -132,11 +132,9 @@ Completed in this phase:
 - NIP-45 Event Counts (Nip45Service + relay COUNT, tests) — PR #78
 - NIP-50 Search Capability (filter.search + tests) — PR #79
 - NIP-09 Event Deletion (relay support + test) — PR #80
+- NIP-61 Nutzaps (NutzapService, tests) — PR #105
 
 Priority now (do these before any other backlog):
-- NIP-15 Nostr Marketplace — commerce flows (listing/bid semantics, tags)
-- NIP-60 Cashu Wallets — wallet helpers and flows; complements NIP‑87
-- NIP-61 Nutzaps — zap semantics extension; align with NIP‑57 ZapService
 - NIP-86 Relay Management API — admin/management events + relay limitations
 
 Backlog (to be scheduled; implement with tests and update docs/SUPPORTED_NIPS.md):

--- a/docs/SUPPORTED_NIPS.md
+++ b/docs/SUPPORTED_NIPS.md
@@ -82,6 +82,7 @@ Keep this file up to date whenever adding or removing support.
 | 88 | Polls | `~/code/nips/88.md` | `src/client/Nip88Service.ts` | `src/client/Nip88Service.test.ts` |
 | 89 | Recommended application handlers | `~/code/nips/89.md` | `src/client/HandlerService.ts` | `src/client/HandlerService.test.ts` |
 | 90 | Data vending machine | `~/code/nips/90.md` | `src/client/DVMService.ts` | `src/client/DVMService.test.ts` |
+| 86 | Relay Management API | `~/code/nips/86.md` | `src/relay/core/nip/modules/Nip86Module.ts`, `src/relay/backends/bun/BunServer.ts` | `src/relay/Nip86Management.test.ts` |
 | 94 | File metadata | `~/code/nips/94.md` | `src/core/Nip94.ts`, `src/wrappers/nip94.ts` | `src/core/Nip94.test.ts` |
 | 96 | HTTP file storage | `~/code/nips/96.md` | `src/wrappers/nip96.ts` | `src/wrappers/nip96.test.ts` |
 | 98 | HTTP auth | `~/code/nips/98.md` | `src/wrappers/nip98.ts` | `src/core/Nip98.test.ts` |

--- a/docs/UNSUPPORTED_NIPS.md
+++ b/docs/UNSUPPORTED_NIPS.md
@@ -9,7 +9,6 @@ Source of truth for supported NIPs: `docs/SUPPORTED_NIPS.md`.
 - 38 — `~/code/nips/38.md`
 - 55 — `~/code/nips/55.md`
 - 77 — `~/code/nips/77.md`
-- 86 — `~/code/nips/86.md`
 - 92 — `~/code/nips/92.md`
 
 Notes

--- a/src/relay/Nip86Management.test.ts
+++ b/src/relay/Nip86Management.test.ts
@@ -1,0 +1,105 @@
+/**
+ * NIP-86 Management API tests
+ */
+import { describe, test, expect, beforeAll, afterAll } from "bun:test"
+import { startTestRelay, type RelayHandle } from "./index.js"
+import { sha256 } from "@noble/hashes/sha256"
+import { bytesToHex, randomBytes } from "@noble/hashes/utils"
+import { schnorr } from "@noble/curves/secp256k1"
+import { HTTP_AUTH_KIND, type EventTemplate } from "../core/Nip98.js"
+
+function generateSecretKey(): Uint8Array {
+  return randomBytes(32)
+}
+
+function getPublicKey(sk: Uint8Array): string {
+  return bytesToHex(schnorr.getPublicKey(sk))
+}
+
+function finalizeEvent(event: EventTemplate, sk: Uint8Array) {
+  const pubkey = getPublicKey(sk)
+  const serialized = JSON.stringify([
+    0,
+    pubkey,
+    event.created_at,
+    event.kind,
+    event.tags,
+    event.content,
+  ])
+  const id = bytesToHex(sha256(new TextEncoder().encode(serialized)))
+  const sig = bytesToHex(schnorr.sign(id, sk))
+  return { id, pubkey, created_at: event.created_at, kind: event.kind, tags: event.tags as any, content: event.content, sig }
+}
+
+const getToken = async (url: string, method: string, payload?: any, withScheme = true) => {
+  const sk = generateSecretKey()
+  const tags: string[][] = [["u", url], ["method", method.toLowerCase()]]
+  if (payload) tags.push(["payload", bytesToHex(sha256(new TextEncoder().encode(JSON.stringify(payload))))])
+  const ev: EventTemplate = { kind: HTTP_AUTH_KIND, tags, created_at: Math.round(Date.now() / 1000) as any, content: "" }
+  const signed = finalizeEvent(ev, sk)
+  const scheme = withScheme ? "Nostr " : ""
+  return scheme + btoa(JSON.stringify(signed))
+}
+
+describe("NIP-86 Management API", () => {
+  let relay: RelayHandle
+  let port: number
+  let baseUrl: string
+
+  beforeAll(async () => {
+    port = 20000 + Math.floor(Math.random() * 10000)
+    relay = await startTestRelay(port)
+    baseUrl = `http://localhost:${port}/`
+  })
+
+  afterAll(async () => {
+    await (await import("effect")).Effect.runPromise(relay.stop())
+  })
+
+  const rpc = async (method: string, params: any[] = []) => {
+    const body = { method, params }
+    const token = await getToken(baseUrl, "post", body, true)
+    const res = await fetch(baseUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/nostr+json+rpc",
+        Authorization: token,
+      },
+      body: JSON.stringify(body),
+    })
+    return res
+  }
+
+  test("supportedmethods returns list", async () => {
+    const res = await rpc("supportedmethods")
+    expect(res.status).toBe(200)
+    const json: any = await res.json()
+    expect(Array.isArray(json.result)).toBe(true)
+    expect(json.result).toContain("banpubkey")
+  })
+
+  test("ban/list banned pubkeys", async () => {
+    const pk = "a".repeat(64)
+    let res = await rpc("banpubkey", [pk, "spammer"]) ; expect(res.status).toBe(200)
+    res = await rpc("listbannedpubkeys") ; const json: any = await res.json()
+    expect(json.result.some((x: any) => x.pubkey === pk)).toBe(true)
+  })
+
+  test("change relay name updates NIP-11 GET /", async () => {
+    const res = await rpc("changerelayname", ["My Relay"]) ; expect(res.status).toBe(200)
+    const info = await fetch(baseUrl, { headers: { accept: "application/nostr+json" } })
+    expect(info.status).toBe(200)
+    const json: any = await info.json()
+    expect(json.name).toBe("My Relay")
+  })
+
+  test("401 when Authorization missing or invalid", async () => {
+    const body = { method: "supportedmethods", params: [] }
+    const res = await fetch(baseUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/nostr+json+rpc" },
+      body: JSON.stringify(body),
+    })
+    expect(res.status).toBe(401)
+  })
+})

--- a/src/relay/core/admin/Nip86AdminService.ts
+++ b/src/relay/core/admin/Nip86AdminService.ts
@@ -1,0 +1,139 @@
+/**
+ * Nip86AdminService
+ *
+ * In-memory admin state and handlers for NIP-86 Management API.
+ */
+import { Context, Effect, Layer } from "effect"
+import type { RelayInfo } from "../RelayInfo.js"
+
+export interface PubkeyEntry { readonly pubkey: string; readonly reason?: string }
+export interface EventEntry { readonly id: string; readonly reason?: string }
+export interface IpEntry { readonly ip: string; readonly reason?: string }
+
+export interface Nip86AdminService {
+  readonly _tag: "Nip86AdminService"
+
+  // Relay info mutations
+  changeRelayName(name: string): Effect.Effect<boolean>
+  changeRelayDescription(description: string): Effect.Effect<boolean>
+  changeRelayIcon(iconUrl: string): Effect.Effect<boolean>
+  getRelayInfo(): Effect.Effect<Partial<RelayInfo>>
+
+  // Pubkeys
+  banPubkey(pubkey: string, reason?: string): Effect.Effect<boolean>
+  listBannedPubkeys(): Effect.Effect<readonly PubkeyEntry[]>
+  allowPubkey(pubkey: string, reason?: string): Effect.Effect<boolean>
+  listAllowedPubkeys(): Effect.Effect<readonly PubkeyEntry[]>
+
+  // Events
+  allowEvent(id: string, reason?: string): Effect.Effect<boolean>
+  banEvent(id: string, reason?: string): Effect.Effect<boolean>
+  listBannedEvents(): Effect.Effect<readonly EventEntry[]>
+  listEventsNeedingModeration(): Effect.Effect<readonly EventEntry[]>
+
+  // Kinds
+  allowKind(kind: number): Effect.Effect<boolean>
+  disallowKind(kind: number): Effect.Effect<boolean>
+  listAllowedKinds(): Effect.Effect<readonly number[]>
+
+  // IPs
+  blockIp(ip: string, reason?: string): Effect.Effect<boolean>
+  unblockIp(ip: string): Effect.Effect<boolean>
+  listBlockedIps(): Effect.Effect<readonly IpEntry[]>
+}
+
+export const Nip86AdminService = Context.GenericTag<Nip86AdminService>("Nip86AdminService")
+
+export const Nip86AdminServiceLive = (initialInfo: Partial<RelayInfo> = {}) =>
+  Layer.effect(
+    Nip86AdminService,
+    Effect.sync(() => {
+      // Mutable in-memory state (per server instance)
+      const bannedPubkeys = new Map<string, string | undefined>()
+      const allowedPubkeys = new Map<string, string | undefined>()
+      const bannedEvents = new Map<string, string | undefined>()
+      const moderationQueue: EventEntry[] = []
+      const allowedKinds = new Set<number>()
+      const blockedIps = new Map<string, string | undefined>()
+      const relayInfo: Partial<RelayInfo> = { ...initialInfo }
+
+      const toList = <T extends { [k: string]: any }>(m: Map<string, any>, key: string): readonly T[] =>
+        [...m.entries()].map(([k, v]) => (v ? ({ [key]: k, reason: v } as any) : ({ [key]: k } as any)))
+
+      const svc: Nip86AdminService = {
+        _tag: "Nip86AdminService",
+
+        changeRelayName: (name) => Effect.sync(() => {
+          ;(relayInfo as any).name = name
+          return true
+        }),
+
+        changeRelayDescription: (description) => Effect.sync(() => {
+          ;(relayInfo as any).description = description
+          return true
+        }),
+
+        changeRelayIcon: (iconUrl) => Effect.sync(() => {
+          ;(relayInfo as any).icon = iconUrl
+          return true
+        }),
+
+        getRelayInfo: () => Effect.succeed(relayInfo),
+
+        banPubkey: (pubkey, reason) => Effect.sync(() => {
+          bannedPubkeys.set(pubkey, reason)
+          return true
+        }),
+
+        listBannedPubkeys: () => Effect.succeed(toList<PubkeyEntry>(bannedPubkeys, "pubkey")),
+
+        allowPubkey: (pubkey, reason) => Effect.sync(() => {
+          allowedPubkeys.set(pubkey, reason)
+          return true
+        }),
+
+        listAllowedPubkeys: () => Effect.succeed(toList<PubkeyEntry>(allowedPubkeys, "pubkey")),
+
+        allowEvent: (id, _reason) => Effect.sync(() => {
+          bannedEvents.delete(id)
+          return true
+        }),
+
+        banEvent: (id, reason) => Effect.sync(() => {
+          bannedEvents.set(id, reason)
+          return true
+        }),
+
+        listBannedEvents: () => Effect.succeed(toList<EventEntry>(bannedEvents, "id")),
+
+        listEventsNeedingModeration: () => Effect.succeed([...moderationQueue]),
+
+        allowKind: (kind) => Effect.sync(() => {
+          allowedKinds.add(kind)
+          return true
+        }),
+
+        disallowKind: (kind) => Effect.sync(() => {
+          allowedKinds.delete(kind)
+          return true
+        }),
+
+        listAllowedKinds: () => Effect.succeed([...allowedKinds.values()]),
+
+        blockIp: (ip, reason) => Effect.sync(() => {
+          blockedIps.set(ip, reason)
+          return true
+        }),
+
+        unblockIp: (ip) => Effect.sync(() => {
+          blockedIps.delete(ip)
+          return true
+        }),
+
+        listBlockedIps: () => Effect.succeed(toList<IpEntry>(blockedIps, "ip")),
+      }
+
+      return svc
+    })
+  )
+

--- a/src/relay/core/nip/modules/Nip86Module.ts
+++ b/src/relay/core/nip/modules/Nip86Module.ts
@@ -1,0 +1,9 @@
+import { createModule, type NipModule } from "../NipModule.js"
+
+export const Nip86Module: NipModule = createModule({
+  id: "nip-86",
+  nips: [86],
+  description: "Relay Management API over HTTP (JSON-RPC with NIP-98 auth)",
+  kinds: [],
+})
+

--- a/src/relay/core/nip/modules/index.ts
+++ b/src/relay/core/nip/modules/index.ts
@@ -17,6 +17,7 @@ export { Nip50Module } from "./Nip50Module.js"
 export { Nip62Module } from "./Nip62Module.js"
 export { Nip70Module } from "./Nip70Module.js"
 export { Nip15Module } from "./Nip15Module.js"
+export { Nip86Module } from "./Nip86Module.js"
 export {
   createNip42Module,
   verifyAuthEvent,
@@ -41,6 +42,7 @@ import { Nip50Module } from "./Nip50Module.js"
 import { Nip62Module } from "./Nip62Module.js"
 import { Nip70Module } from "./Nip70Module.js"
 import { Nip15Module } from "./Nip15Module.js"
+import { Nip86Module } from "./Nip86Module.js"
 import type { NipModule } from "../NipModule.js"
 
 /**
@@ -60,4 +62,5 @@ export const DefaultModules: readonly NipModule[] = [
   Nip62Module,
   Nip70Module,
   Nip15Module,
+  Nip86Module,
 ]

--- a/src/relay/index.ts
+++ b/src/relay/index.ts
@@ -38,6 +38,7 @@ import { DefaultModules } from "./core/nip/modules/index.js"
 import type { NipModule } from "./core/nip/NipModule.js"
 import { EventServiceLive } from "../services/EventService.js"
 import { CryptoServiceLive } from "../services/CryptoService.js"
+import { Nip86AdminServiceLive } from "./core/admin/Nip86AdminService.js"
 
 // =============================================================================
 // Re-exports - Storage
@@ -146,6 +147,7 @@ export const makeRelayLayerWithNips = (
     Layer.provide(SubscriptionManagerLive),
     Layer.provide(NipRegistryLive(modules)),
     Layer.provide(BunSqliteStoreLive(dbPath)),
+    Layer.provide(Nip86AdminServiceLive()),
     Layer.provide(EventServiceLive),
     Layer.provide(CryptoServiceLive)
   )
@@ -164,6 +166,7 @@ export const makeMemoryRelayLayerWithNips = (
     Layer.provide(SubscriptionManagerLive),
     Layer.provide(NipRegistryLive(modules)),
     Layer.provide(MemoryEventStoreLive),
+    Layer.provide(Nip86AdminServiceLive()),
     Layer.provide(EventServiceLive),
     Layer.provide(CryptoServiceLive)
   )


### PR DESCRIPTION
Implements NIP-86 Management API:\n- HTTP JSON-RPC handler in BunServer with NIP-98 Authorization (payload required)\n- In-memory Nip86AdminService state (pubkeys, events, kinds, IPs, relay info)\n- Nip86Module registered and added to DefaultModules (NIP-11 supported_nips)\n- Tests: src/relay/Nip86Management.test.ts (supportedmethods, ban/list pubkeys, changerelayname, 401 on missing auth)\n- Docs: add NIP-86 to docs/SUPPORTED_NIPS.md; remove from docs/UNSUPPORTED_NIPS.md\n\nAll tests pass via bun test v1.3.0 (b0a6feca)
Connected to 3/3 relays
Connection status: {
  "wss://nos.lol": true,
  "wss://relay.damus.io": true,
  "wss://relay.primal.net": true,
}
Event 2a5ca644 from wss://relay.damus.io
Event cfb13f41 from wss://relay.damus.io
Event b9d162c3 from wss://relay.damus.io
Event 0170f7d1 from wss://relay.damus.io
Event 85eae607 from wss://relay.damus.io
Event bb16ac74 from wss://nos.lol
Event 4bddf32d from wss://nos.lol
Event 0c2e69eb from wss://nos.lol
Event 95238bad from wss://nos.lol
Event 740a3ad8 from wss://nos.lol
Event ecd1d374 from wss://relay.primal.net
Event 29632d58 from wss://relay.primal.net
Event a9e6dd86 from wss://relay.primal.net
Event 0d4970a8 from wss://relay.primal.net
EOSE received (1/3)
Total events received: 14
Events per relay: {
  "wss://nos.lol": 5,
  "wss://relay.damus.io": 5,
  "wss://relay.primal.net": 4,
}
Final connection status: {
  "wss://nos.lol": true,
  "wss://relay.damus.io": true,
  "wss://relay.primal.net": true,
}
querySync returned 22 events
Connection status: {
  "wss://nos.lol": true,
  "wss://relay.damus.io": true,
  "wss://relay.primal.net": true,
}
Received 42 events, 42 unique
Got 7 events despite bad relay
Status after connect: {
  "wss://nos.lol": true,
}.