### PR TITLE
feat(nip24): Extra metadata fields & common tags helpers + tests; docs

### DIFF
--- a/docs/SUPPORTED_NIPS.md
+++ b/docs/SUPPORTED_NIPS.md
@@ -31,6 +31,7 @@ Keep this file up to date whenever adding or removing support.
 | 21 | nostr: URI scheme | `~/code/nips/21.md` | `src/core/Nip21.ts`, `src/wrappers/nip21.ts` | `src/core/Nip21.test.ts` |
 | 22 | Comment | `~/code/nips/22.md` | `src/wrappers/nip22.ts` | `src/wrappers/nip22.test.ts` |
 | 23 | Long-form content | `~/code/nips/23.md` | `src/client/Nip23Service.ts` | `src/client/Nip23Service.test.ts` |
+| 24 | Extra metadata fields and tags | `~/code/nips/24.md` | `src/wrappers/nip24.ts` | `src/wrappers/nip24.test.ts` |
 | 25 | Reactions | `~/code/nips/25.md` | `src/client/Nip25Service.ts` | `src/client/Nip25Service.test.ts` |
 | 26 | Delegated event signing | `~/code/nips/26.md` | `src/wrappers/nip26.ts` | `src/wrappers/nip26.test.ts` |
 | 27 | Content parsing | `~/code/nips/27.md` | `src/wrappers/nip27.ts` | `src/core/Nip27.test.ts` |

--- a/docs/UNSUPPORTED_NIPS.md
+++ b/docs/UNSUPPORTED_NIPS.md
@@ -5,7 +5,6 @@ This file lists NIPs present in the local specs repo (`~/code/nips`) that are no
 Source of truth for supported NIPs: `docs/SUPPORTED_NIPS.md`.
 
 - 12 — `~/code/nips/12.md`
-- 24 — `~/code/nips/24.md`
 - 38 — `~/code/nips/38.md`
 - 55 — `~/code/nips/55.md`
 - 77 — `~/code/nips/77.md`

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "./nip07": "./src/wrappers/nip07.ts",
     "./nip10": "./src/wrappers/nip10.ts",
     "./nip22": "./src/wrappers/nip22.ts",
+    "./nip24": "./src/wrappers/nip24.ts",
     "./nip11": "./src/wrappers/nip11.ts",
     "./nip13": "./src/wrappers/nip13.ts",
     "./nip15": "./src/wrappers/nip15.ts",

--- a/src/wrappers/nip24.test.ts
+++ b/src/wrappers/nip24.test.ts
@@ -1,0 +1,66 @@
+/**
+ * NIP-24: Extra metadata fields and tags
+ */
+import { describe, test, expect } from "bun:test"
+import {
+  stringifyMetadata,
+  normalizeMetadata,
+  withUrlTag,
+  withExternalIdTag,
+  withTitleTag,
+  withHashtags,
+} from "./nip24.js"
+
+describe("NIP-24 metadata helpers", () => {
+  test("stringifyMetadata includes extra fields and stable ordering", () => {
+    const json = stringifyMetadata({
+      name: "alice",
+      display_name: "Alice A.",
+      website: "https://alice.example",
+      banner: "https://img/banner.jpg",
+      bot: false,
+      birthday: { year: 1990, month: 5 },
+      about: "hello",
+    })
+    const obj = JSON.parse(json)
+    expect(obj.name).toBe("alice")
+    expect(obj.display_name).toBe("Alice A.")
+    expect(obj.website).toBe("https://alice.example")
+    expect(obj.banner).toBe("https://img/banner.jpg")
+    expect(obj.bot).toBe(false)
+    expect(obj.birthday.year).toBe(1990)
+    expect(obj.birthday.month).toBe(5)
+    expect(obj.about).toBe("hello")
+  })
+
+  test("normalizeMetadata maps deprecated fields", () => {
+    const out = normalizeMetadata({ username: "bob", displayName: "Bobby" })
+    expect(out.name).toBe("bob")
+    expect(out.display_name).toBe("Bobby")
+    expect((out as any).username).toBeUndefined()
+    expect((out as any).displayName).toBeUndefined()
+  })
+})
+
+describe("NIP-24 tag helpers", () => {
+  test("withUrlTag/withExternalIdTag/withTitleTag add tags", () => {
+    let tags: string[][] = []
+    tags = withUrlTag(tags, "https://example")
+    tags = withExternalIdTag(tags, "ext-1")
+    tags = withTitleTag(tags, "My Set")
+    expect(tags).toContainEqual(["r", "https://example"])
+    expect(tags).toContainEqual(["i", "ext-1"])
+    expect(tags).toContainEqual(["title", "My Set"])
+  })
+
+  test("withHashtags lowercases and deduplicates", () => {
+    let tags: string[][] = [["t", "news"], ["t", "tech"]]
+    tags = withHashtags(tags, ["Tech", "Gossip", "news"]) // "news" already exists
+    expect(tags).toContainEqual(["t", "tech"]) // original
+    expect(tags).toContainEqual(["t", "gossip"]) // added lowercased
+    // ensure no duplicate for "tech"
+    const techCount = tags.filter((t) => t[0] === "t" && t[1] === "tech").length
+    expect(techCount).toBe(1)
+  })
+})
+

--- a/src/wrappers/nip24.ts
+++ b/src/wrappers/nip24.ts
@@ -1,0 +1,108 @@
+/**
+ * NIP-24: Extra metadata fields and tags
+ *
+ * Helpers for kind 0 metadata JSON (extra fields) and common tags.
+ * Spec: ~/code/nips/24.md
+ */
+
+// =============================================================================
+// Metadata (kind 0) helpers
+// =============================================================================
+
+export interface ProfileMetadata {
+  readonly name?: string
+  readonly about?: string
+  readonly picture?: string
+  // NIP-24 extras
+  readonly display_name?: string
+  readonly website?: string
+  readonly banner?: string
+  readonly bot?: boolean
+  readonly birthday?: Partial<{ year: number; month: number; day: number }>
+  // Allow arbitrary extra fields
+  readonly [k: string]: unknown
+}
+
+/** Convert a metadata object to a canonical JSON string (stable-ish order). */
+export function stringifyMetadata(meta: ProfileMetadata): string {
+  // Normalize deprecated fields if present
+  const normalized = normalizeMetadata(meta)
+  // Keep a predictable key order for the common fields; append the rest
+  const orderedKeys = [
+    "name",
+    "about",
+    "picture",
+    "display_name",
+    "website",
+    "banner",
+    "bot",
+    "birthday",
+  ]
+  const out: Record<string, unknown> = {}
+  for (const k of orderedKeys) if (k in normalized) out[k] = (normalized as any)[k]
+  for (const k of Object.keys(normalized)) if (!(k in out)) out[k] = (normalized as any)[k]
+  return JSON.stringify(out)
+}
+
+/** Normalize deprecated fields and ensure types are valid per NIP-24 guidance. */
+export function normalizeMetadata(meta: Record<string, unknown>): ProfileMetadata {
+  const out: Record<string, unknown> = { ...meta }
+  // Deprecated: displayName -> display_name
+  if (typeof out.displayName === "string" && !out.display_name) {
+    out.display_name = out.displayName
+  }
+  delete (out as any).displayName
+  // Deprecated: username -> name
+  if (typeof out.username === "string" && !out.name) {
+    out.name = out.username
+  }
+  delete (out as any).username
+  // Ensure birthday partial object stays within expected keys
+  if (out.birthday && typeof out.birthday === "object") {
+    const src = out.birthday as any
+    const b: any = {}
+    if (typeof src.year === "number") b.year = src.year
+    if (typeof src.month === "number") b.month = src.month
+    if (typeof src.day === "number") b.day = src.day
+    out.birthday = b
+  }
+  // bot must be boolean if present
+  if (out.bot != null) out.bot = Boolean(out.bot)
+  return out as ProfileMetadata
+}
+
+// =============================================================================
+// Tag helpers (generic, used across kinds)
+// =============================================================================
+
+/** Add or replace a single URL reference tag (r). */
+export function withUrlTag(tags: string[][], url: string): string[][] {
+  return [...tags, ["r", url]]
+}
+
+/** Add external id tag (i). Prefer NIP-73 when appropriate. */
+export function withExternalIdTag(tags: string[][], id: string): string[][] {
+  return [...tags, ["i", id]]
+}
+
+/** Add a title tag for sets/live events/calendar/listings. */
+export function withTitleTag(tags: string[][], title: string): string[][] {
+  return [...tags, ["title", title]]
+}
+
+/** Add one or more hashtags (t). Enforces lowercase and deduplicates. */
+export function withHashtags(tags: string[][], hashtags: readonly string[]): string[][] {
+  const existing = new Set(
+    tags.filter((t) => t[0] === "t").map((t) => (t[1] ?? "").toLowerCase())
+  )
+  const out = [...tags]
+  for (const raw of hashtags) {
+    const v = String(raw).toLowerCase()
+    if (!existing.has(v)) {
+      out.push(["t", v])
+      existing.add(v)
+    }
+  }
+  return out
+}
+


### PR DESCRIPTION
Implements NIP-24 support:\n- Metadata helpers (kind 0): stringifyMetadata, normalizeMetadata\n- Tag helpers: withUrlTag, withExternalIdTag, withTitleTag, withHashtags (lowercase, dedupe)\n- Tests: src/wrappers/nip24.test.ts\n- Export mapping and docs updates (SUPPORTED/UNSUPPORTED)\n\nAll tests pass via bun run verify.