### PR TITLE
feat(relay): persist signed NIP-29 group state

### DIFF
--- a/docs/2026-07-24-node-google-cloud-migration.md
+++ b/docs/2026-07-24-node-google-cloud-migration.md
@@ -143,8 +143,9 @@ multi-replica operator notes.
 
 Exit: the relay is live, measured, monitored, and has a public-safe receipt.
 
-The production entry now fails closed unless `DATABASE_URL` and the origin-only
-`RELAY_PUBLIC_URL` are present. It composes the Node host with the Cloud SQL
+The production entry now fails closed unless `DATABASE_URL`, the origin-only
+`RELAY_PUBLIC_URL`, `RELAY_PRIVATE_KEY`, and `RELAY_NIP29_SEED_GROUPS` are
+present. It composes the Node host with the Cloud SQL
 Postgres store, requires NIP-42 on connections, drains WebSockets on SIGTERM,
 and closes the database pool. The root Dockerfile builds the Node 24 Cloud Run
 image; deployment, DNS, remote load proof, backup/restore, and multi-replica

--- a/docs/nip29-group-policy.md
+++ b/docs/nip29-group-policy.md
@@ -1,8 +1,52 @@
-# NIP-29 group policy for the owned relay (SARAH-CW-01)
+# NIP-29 group policy and durable Node host
 
 This document describes how the owned OpenAgents relay admits a closed NIP-29
 group, enforces membership on write, and publishes relay-signed membership
 state that a client can verify.
+
+The Node host is generic. An operator can also configure a public group. The
+host does not depend on an application account or session. NIP-42 authenticates
+the Nostr key on the relay connection.
+
+## Durable production configuration
+
+The standalone Node entry requires these values in addition to `DATABASE_URL`
+and `RELAY_PUBLIC_URL`:
+
+```sh
+RELAY_PRIVATE_KEY="<64 lowercase hex characters>"
+RELAY_NIP29_SEED_GROUPS='[
+  {
+    "id": "public-chat",
+    "name": "Public Chat",
+    "about": "A public NIP-29 chat group.",
+    "isClosed": false,
+    "isRestricted": false,
+    "isPrivate": false,
+    "isHidden": false,
+    "supportedKinds": [5, 7, 9, 1337, 1984]
+  }
+]'
+```
+
+Load `RELAY_PRIVATE_KEY` from the deployment secret store. Do not put it in
+source control, an event, a log, or the group JSON. The relay derives the
+lowercase public key and publishes it as NIP-11 `self`.
+
+Before the listener starts, the host validates the inputs, replays stored
+moderation history, and stores signed kinds `39000`, `39001`, `39003`, and
+`39005`. Startup stops when a required read, signature, or write fails. An
+unchanged restart keeps the same event IDs.
+
+Accepted metadata and pin moderation events regenerate the affected
+relay-signed state. Use one relay process for moderation writes. Restart replay
+preserves state, but this release does not coordinate the in-memory policy
+engine across concurrent relay processes.
+
+When a group event contains `previous` references, each reference must be the
+first eight lowercase hexadecimal characters of an event in the last 50 events
+from that relay group. The referenced event must have a different author. The
+tag remains optional, as NIP-29 specifies.
 
 ## Why
 
@@ -91,8 +135,9 @@ function publishMembership(groupId: string) {
   const admins = finalizeEvent(proj.admins, relaySecret)
   const members = finalizeEvent(proj.members, relaySecret)
   const roles = finalizeEvent(proj.roles, relaySecret)
+  const pinned = finalizeEvent(proj.pinned, relaySecret)
   // Store/broadcast metadata, admins, members, roles through the relay host.
-  return { metadata, admins, members, roles }
+  return { metadata, admins, members, roles, pinned }
 }
 
 publishMembership("openagents-community")
@@ -181,6 +226,7 @@ engine.admitEvent({ pubkey, kind: 1, tags: [["h", "g"]], content: "" })
 | --- | --- |
 | Pure engine | `src/core/Nip29GroupPolicy.ts` |
 | Relay module factory | `src/relay/core/nip/modules/Nip29Module.ts` (`createNip29GroupPolicyModule`) |
+| Durable Node host | `src/relay/backends/node/RelayNip29Host.ts` |
 | Advertisement-only module | `Nip29Module` (default module set) |
 | Client loaders/parsers | `src/client/Nip29Service.ts`, `src/wrappers/nip29.ts` |
 | Tests | `src/core/Nip29GroupPolicy.test.ts`, `src/relay/core/nip/modules/Nip29Module.test.ts` |

--- a/src/core/Nip29GroupPolicy.ts
+++ b/src/core/Nip29GroupPolicy.ts
@@ -164,6 +164,8 @@ export interface GroupRecord {
   readonly invites: ReadonlySet<string>
   /** Supported content kinds; empty means all kinds when unset */
   readonly supportedKinds?: readonly number[]
+  /** Ordered event and address references mirrored by kind 39005. */
+  readonly pinnedReferences: readonly (readonly ["e" | "a", string])[]
 }
 
 export interface GroupPolicyConfig {
@@ -464,6 +466,8 @@ export class GroupPolicyEngine {
     readonly isHidden?: boolean
     readonly creatorRoles?: readonly string[]
     readonly creatorCapabilityGrants?: readonly string[]
+    readonly supportedKinds?: readonly number[]
+    readonly pinnedReferences?: readonly (readonly ["e" | "a", string])[]
   }): AdmitDecision {
     if (this.groups.has(params.id) && !this.groups.get(params.id)!.deleted) {
       return { admit: false, reason: "duplicate: group already exists" }
@@ -494,6 +498,10 @@ export class GroupPolicyEngine {
       deleted: false,
       members,
       invites: new Set(),
+      ...(params.supportedKinds !== undefined
+        ? { supportedKinds: [...params.supportedKinds] }
+        : {}),
+      pinnedReferences: [...(params.pinnedReferences ?? [])],
     }
     this.groups.set(params.id, record)
     return { admit: true }
@@ -610,13 +618,20 @@ export class GroupPolicyEngine {
     readonly isClosed?: boolean
     readonly isRestricted?: boolean
     readonly isHidden?: boolean
+    readonly supportedKinds?: readonly number[]
+    /** Remove supportedKinds when the full metadata event omits the tag. */
+    readonly replaceSupportedKinds?: boolean
   }): AdmitDecision {
     const g = this.groups.get(params.groupId)
     if (!g || g.deleted) {
       return { admit: false, reason: "restricted: group not found" }
     }
+    const {
+      supportedKinds: _supportedKinds,
+      ...groupWithoutSupportedKinds
+    } = g
     this.groups.set(params.groupId, {
-      ...g,
+      ...groupWithoutSupportedKinds,
       ...(params.name !== undefined ? { name: params.name } : {}),
       ...(params.about !== undefined ? { about: params.about } : {}),
       ...(params.picture !== undefined ? { picture: params.picture } : {}),
@@ -627,6 +642,13 @@ export class GroupPolicyEngine {
         ? { isRestricted: params.isRestricted }
         : {}),
       ...(params.isHidden !== undefined ? { isHidden: params.isHidden } : {}),
+      ...(params.supportedKinds !== undefined
+        ? { supportedKinds: [...params.supportedKinds] }
+        : params.replaceSupportedKinds === true
+          ? {}
+          : _supportedKinds !== undefined
+            ? { supportedKinds: _supportedKinds }
+            : {}),
     })
     return { admit: true }
   }
@@ -935,6 +957,7 @@ export class GroupPolicyEngine {
       let isClosed: boolean | undefined
       let isRestricted: boolean | undefined
       let isHidden: boolean | undefined
+      let supportedKinds: readonly number[] | undefined
       for (const t of event.tags) {
         if (t[0] === "name" && t[1] !== undefined) name = t[1]
         if (t[0] === "about" && t[1] !== undefined) about = t[1]
@@ -944,6 +967,22 @@ export class GroupPolicyEngine {
         if (t[0] === "closed") isClosed = true
         if (t[0] === "restricted") isRestricted = true
         if (t[0] === "hidden") isHidden = true
+        if (t[0] === "supported_kinds") {
+          const parsed = t
+            .slice(1)
+            .map(Number)
+            .filter(
+              (kind) =>
+                Number.isSafeInteger(kind) && kind >= 0 && kind <= 65_535
+            )
+          if (parsed.length !== t.length - 1) {
+            return {
+              applied: false,
+              reason: "invalid: supported_kinds contains an invalid event kind",
+            }
+          }
+          supportedKinds = parsed
+        }
       }
       const decision = this.editMetadata({
         groupId,
@@ -951,10 +990,14 @@ export class GroupPolicyEngine {
         ...(about !== undefined ? { about } : {}),
         ...(picture !== undefined ? { picture } : {}),
         ...(banner !== undefined ? { banner } : {}),
-        ...(isPrivate !== undefined ? { isPrivate } : {}),
-        ...(isClosed !== undefined ? { isClosed } : {}),
-        ...(isRestricted !== undefined ? { isRestricted } : {}),
-        ...(isHidden !== undefined ? { isHidden } : {}),
+        // Kind 9002 carries the full metadata state. Missing flag tags clear
+        // their flags instead of preserving stale state.
+        isPrivate: isPrivate ?? false,
+        isClosed: isClosed ?? false,
+        isRestricted: isRestricted ?? false,
+        isHidden: isHidden ?? false,
+        ...(supportedKinds !== undefined ? { supportedKinds } : {}),
+        replaceSupportedKinds: true,
       })
       return decision.admit
         ? { applied: true }
@@ -1007,11 +1050,28 @@ export class GroupPolicyEngine {
       return { applied: true, revocation }
     }
 
-    // delete-event / update-pin-list do not change membership state here.
+    // delete-event does not change the state represented by this engine.
     if (
       event.kind === GROUP_DELETE_EVENT_KIND ||
       event.kind === GROUP_UPDATE_PIN_LIST_KIND
     ) {
+      if (event.kind === GROUP_UPDATE_PIN_LIST_KIND) {
+        const groupId = getHTag(event)
+        if (!groupId) return { applied: false, reason: "missing h" }
+        const group = this.groups.get(groupId)
+        if (!group || group.deleted) {
+          return { applied: false, reason: "restricted: group not found" }
+        }
+        const pinnedReferences = event.tags
+          .filter(
+            (tag) =>
+              (tag[0] === "e" || tag[0] === "a") &&
+              typeof tag[1] === "string" &&
+              tag[1].length > 0
+          )
+          .map((tag) => [tag[0] as "e" | "a", tag[1]!] as const)
+        this.groups.set(groupId, { ...group, pinnedReferences })
+      }
       return { applied: true }
     }
 
@@ -1036,6 +1096,7 @@ export class GroupPolicyEngine {
         readonly admins: EventTemplate
         readonly members: EventTemplate
         readonly roles: EventTemplate
+        readonly pinned: EventTemplate
       }
     | { readonly ok: false; readonly reason: string } {
     const g = this.groups.get(groupId)
@@ -1052,6 +1113,12 @@ export class GroupPolicyEngine {
     if (g.isClosed) metadataTags.push(["closed"])
     if (g.isRestricted) metadataTags.push(["restricted"])
     if (g.isHidden) metadataTags.push(["hidden"])
+    if (g.supportedKinds !== undefined) {
+      metadataTags.push([
+        "supported_kinds",
+        ...g.supportedKinds.map((kind) => String(kind)),
+      ])
+    }
     // Room class as a non-conflicting extension tag for operators.
     metadataTags.push(["room-class", g.roomClass])
 
@@ -1103,6 +1170,15 @@ export class GroupPolicyEngine {
         content: `roles for ${groupId}`,
         created_at: createdAt,
       },
+      pinned: {
+        kind: GROUP_PINNED_EVENTS_KIND,
+        tags: [
+          ["d", groupId],
+          ...g.pinnedReferences.map(([type, value]) => [type, value]),
+        ],
+        content: "",
+        created_at: createdAt,
+      },
     }
   }
 
@@ -1116,6 +1192,7 @@ export class GroupPolicyEngine {
       ...g,
       members,
       invites: new Set(g.invites),
+      pinnedReferences: [...g.pinnedReferences],
     }
   }
 }

--- a/src/relay/backends/node/RelayNip29Host.test.ts
+++ b/src/relay/backends/node/RelayNip29Host.test.ts
@@ -1,0 +1,321 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Effect } from "effect";
+import WebSocket from "ws";
+import { afterEach, describe, expect, test } from "vite-plus/test";
+import type { NostrEvent, RelayMessage } from "../../../core/Schema.js";
+import {
+  finalizeEvent,
+  getPublicKey,
+  verifyEvent,
+  type Event as PureEvent,
+} from "../../../wrappers/pure.js";
+import { openNodeSqliteStore } from "./NodeSqliteStore.js";
+import { createRelayNip29Host } from "./RelayNip29Host.js";
+import { startRelayWithEventStore, type RelayHandle } from "./index.js";
+
+const RELAY_PRIVATE_KEY = "1".repeat(64);
+const WRITER_PRIVATE_KEY = Uint8Array.from({ length: 32 }, () => 2);
+const SECOND_WRITER_PRIVATE_KEY = Uint8Array.from({ length: 32 }, () => 3);
+const GROUP_ID = "public-chat";
+const SUPPORTED_KINDS = [5, 7, 9, 1337, 1984];
+
+const asNostrEvent = (event: ReturnType<typeof finalizeEvent>): NostrEvent =>
+  event as unknown as NostrEvent;
+
+interface BufferedSocket {
+  readonly ws: WebSocket;
+  readonly waitForMessage: (
+    predicate: (message: RelayMessage) => boolean,
+  ) => Promise<RelayMessage>;
+}
+
+const connect = (port: number): Promise<BufferedSocket> =>
+  new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+    const queue: RelayMessage[] = [];
+    const waiters: Array<{
+      readonly predicate: (message: RelayMessage) => boolean;
+      readonly resolve: (message: RelayMessage) => void;
+      readonly timer: ReturnType<typeof setTimeout>;
+    }> = [];
+    ws.on("message", (data: WebSocket.RawData) => {
+      const message = JSON.parse(data.toString()) as RelayMessage;
+      const index = waiters.findIndex((waiter) => waiter.predicate(message));
+      if (index < 0) {
+        queue.push(message);
+        return;
+      }
+      const [waiter] = waiters.splice(index, 1);
+      if (!waiter) return;
+      clearTimeout(waiter.timer);
+      waiter.resolve(message);
+    });
+    const waitForMessage: BufferedSocket["waitForMessage"] = (predicate) => {
+      const index = queue.findIndex(predicate);
+      if (index >= 0) {
+        const [message] = queue.splice(index, 1);
+        return Promise.resolve(message as RelayMessage);
+      }
+      return new Promise((waiterResolve, waiterReject) => {
+        const timer = setTimeout(
+          () => waiterReject(new Error("timeout waiting for relay message")),
+          3_000,
+        );
+        waiters.push({ predicate, resolve: waiterResolve, timer });
+      });
+    };
+    ws.once("open", () => resolve({ ws, waitForMessage }));
+    ws.once("error", reject);
+  });
+
+const authenticate = async (
+  socket: BufferedSocket,
+  port: number,
+  privateKey: Uint8Array,
+): Promise<RelayMessage> => {
+  const challengeMessage = await socket.waitForMessage(
+    (message) => message[0] === "AUTH",
+  );
+  const authEvent = asNostrEvent(
+    finalizeEvent(
+      {
+        kind: 22242,
+        created_at: Math.floor(Date.now() / 1000),
+        tags: [
+          ["relay", `ws://127.0.0.1:${port}`],
+          ["challenge", String(challengeMessage[1])],
+        ],
+        content: "",
+      },
+      privateKey,
+    ),
+  );
+  socket.ws.send(JSON.stringify(["AUTH", authEvent]));
+  return socket.waitForMessage(
+    (message) => message[0] === "OK" && message[1] === authEvent.id,
+  );
+};
+
+const queryGroupState = (
+  store: ReturnType<typeof openNodeSqliteStore>["store"],
+  relayPubkey: string,
+) =>
+  Effect.runPromise(
+    store.queryEvents([
+      {
+        authors: [relayPubkey],
+        kinds: [39000, 39001, 39003, 39005],
+        "#d": [GROUP_ID],
+      } as never,
+    ]),
+  );
+
+describe("RelayNip29Host", () => {
+  const cleanup: Array<() => Promise<void> | void> = [];
+
+  afterEach(async () => {
+    while (cleanup.length > 0) {
+      await cleanup.pop()?.();
+    }
+  });
+
+  test("persists signed seed state, accepts public kind 9, and survives restart", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "nostr-effect-nip29-"));
+    cleanup.push(() => rm(directory, { recursive: true, force: true }));
+    const path = join(directory, "relay.sqlite");
+    const firstStore = openNodeSqliteStore(path);
+    cleanup.push(() => firstStore.close());
+
+    const hostConfig = {
+      relayPrivateKey: RELAY_PRIVATE_KEY,
+      seedGroups: [
+        {
+          id: GROUP_ID,
+          name: "Public Chat",
+          about: "A public NIP-29 chat group.",
+          isClosed: false,
+          isRestricted: false,
+          supportedKinds: SUPPORTED_KINDS,
+        },
+      ],
+    } as const;
+    const firstHost = await createRelayNip29Host(hostConfig, firstStore.store);
+    cleanup.push(firstHost.dispose);
+
+    const initialState = await queryGroupState(firstStore.store, firstHost.relayPubkey);
+    expect(initialState).toHaveLength(4);
+    expect(initialState.every((event) => verifyEvent(event as unknown as PureEvent))).toBe(true);
+    expect(initialState.every((event) => event.pubkey === firstHost.relayPubkey)).toBe(true);
+    const metadata = initialState.find((event) => event.kind === 39000);
+    expect(metadata?.tags).toContainEqual(["supported_kinds", "5", "7", "9", "1337", "1984"]);
+
+    const port = 33_000 + Math.floor(Math.random() * 5_000);
+    const relay: RelayHandle = await startRelayWithEventStore(
+      {
+        port,
+        modules: firstHost.modules,
+        relayInfo: {
+          self: firstHost.relayPubkey,
+          supported_kinds: SUPPORTED_KINDS,
+        },
+        nip42: {
+          relayUrls: [`ws://127.0.0.1:${port}`],
+          authRequired: true,
+        },
+      },
+      firstStore.store,
+    );
+    cleanup.push(() => Effect.runPromise(relay.stop()));
+
+    const infoResponse = await fetch(`http://127.0.0.1:${port}/`, {
+      headers: { Accept: "application/nostr+json" },
+    });
+    const info = (await infoResponse.json()) as {
+      self?: string;
+      supported_nips?: number[];
+      supported_kinds?: number[];
+    };
+    expect(info.self).toBe(firstHost.relayPubkey);
+    expect(info.supported_nips).toContain(29);
+    expect(info.supported_kinds).toEqual(SUPPORTED_KINDS);
+
+    const socket = await connect(port);
+    cleanup.push(() => socket.ws.terminate());
+    const firstMessage = asNostrEvent(
+      finalizeEvent(
+        {
+          kind: 9,
+          created_at: Math.floor(Date.now() / 1000),
+          tags: [["h", GROUP_ID]],
+          content: "hello from an external key",
+        },
+        WRITER_PRIVATE_KEY,
+      ),
+    );
+    socket.ws.send(JSON.stringify(["EVENT", firstMessage]));
+    const unauthenticated = await socket.waitForMessage(
+      (message) => message[0] === "OK" && message[1] === firstMessage.id,
+    );
+    expect(unauthenticated[2]).toBe(false);
+    expect(unauthenticated[3]).toContain("auth-required");
+
+    const authOk = await authenticate(socket, port, WRITER_PRIVATE_KEY);
+    expect(authOk[2]).toBe(true);
+
+    socket.ws.send(JSON.stringify(["EVENT", firstMessage]));
+    const firstOk = await socket.waitForMessage(
+      (message) => message[0] === "OK" && message[1] === firstMessage.id,
+    );
+    expect(firstOk[2]).toBe(true);
+
+    const contextualMessage = asNostrEvent(
+      finalizeEvent(
+        {
+          kind: 9,
+          created_at: firstMessage.created_at + 1,
+          tags: [
+            ["h", GROUP_ID],
+            ["previous", firstMessage.id.slice(0, 8)],
+          ],
+          content: "context-bound reply",
+        },
+        SECOND_WRITER_PRIVATE_KEY,
+      ),
+    );
+    const secondSocket = await connect(port);
+    cleanup.push(() => secondSocket.ws.terminate());
+    expect((await authenticate(secondSocket, port, SECOND_WRITER_PRIVATE_KEY))[2]).toBe(true);
+    secondSocket.ws.send(JSON.stringify(["EVENT", contextualMessage]));
+    const contextualOk = await secondSocket.waitForMessage(
+      (message) => message[0] === "OK" && message[1] === contextualMessage.id,
+    );
+    expect(contextualOk[2]).toBe(true);
+
+    const invalidPrevious = asNostrEvent(
+      finalizeEvent(
+        {
+          kind: 9,
+          created_at: firstMessage.created_at + 2,
+          tags: [
+            ["h", GROUP_ID],
+            ["previous", "deadbeef"],
+          ],
+          content: "invalid context",
+        },
+        SECOND_WRITER_PRIVATE_KEY,
+      ),
+    );
+    secondSocket.ws.send(JSON.stringify(["EVENT", invalidPrevious]));
+    const invalidOk = await secondSocket.waitForMessage(
+      (message) => message[0] === "OK" && message[1] === invalidPrevious.id,
+    );
+    expect(invalidOk[2]).toBe(false);
+
+    const pinned = asNostrEvent(
+      finalizeEvent(
+        {
+          kind: 9010,
+          created_at: firstMessage.created_at + 3,
+          tags: [
+            ["h", GROUP_ID],
+            ["e", firstMessage.id],
+            ["previous", firstMessage.id.slice(0, 8)],
+          ],
+          content: "",
+        },
+        Uint8Array.from(Buffer.from(RELAY_PRIVATE_KEY, "hex")),
+      ),
+    );
+    const relaySocket = await connect(port);
+    cleanup.push(() => relaySocket.ws.terminate());
+    expect(
+      (
+        await authenticate(
+          relaySocket,
+          port,
+          Uint8Array.from(Buffer.from(RELAY_PRIVATE_KEY, "hex")),
+        )
+      )[2],
+    ).toBe(true);
+    relaySocket.ws.send(JSON.stringify(["EVENT", pinned]));
+    const pinnedOk = await relaySocket.waitForMessage(
+      (message) => message[0] === "OK" && message[1] === pinned.id,
+    );
+    expect(pinnedOk[2]).toBe(true);
+    const stateAfterPin = await queryGroupState(firstStore.store, firstHost.relayPubkey);
+    expect(stateAfterPin.find((event) => event.kind === 39005)?.tags).toContainEqual([
+      "e",
+      firstMessage.id,
+    ]);
+
+    const firstStateIds = new Set(stateAfterPin.map((event) => event.id));
+    socket.ws.terminate();
+    secondSocket.ws.terminate();
+    relaySocket.ws.terminate();
+    await Effect.runPromise(relay.stop());
+    firstHost.dispose();
+    firstStore.close();
+    cleanup.splice(1);
+
+    const secondStore = openNodeSqliteStore(path);
+    cleanup.push(() => secondStore.close());
+    const secondHost = await createRelayNip29Host(hostConfig, secondStore.store);
+    cleanup.push(secondHost.dispose);
+    expect(secondHost.relayPubkey).toBe(
+      getPublicKey(Uint8Array.from(Buffer.from(RELAY_PRIVATE_KEY, "hex"))),
+    );
+    const restartedState = await queryGroupState(secondStore.store, secondHost.relayPubkey);
+    expect(new Set(restartedState.map((event) => event.id))).toEqual(firstStateIds);
+    expect(restartedState.find((event) => event.kind === 39005)?.tags).toContainEqual([
+      "e",
+      firstMessage.id,
+    ]);
+    const history = await Effect.runPromise(
+      secondStore.store.queryEvents([{ kinds: [9], "#h": [GROUP_ID] } as never]),
+    );
+    expect(history.map((event) => event.id)).toContain(firstMessage.id);
+    expect(history.map((event) => event.id)).toContain(contextualMessage.id);
+  });
+});

--- a/src/relay/backends/node/RelayNip29Host.ts
+++ b/src/relay/backends/node/RelayNip29Host.ts
@@ -189,6 +189,8 @@ export const createRelayNip29Host = async (
   }
   for (const group of config.seedGroups) validateSeedGroup(group);
 
+  const validatePreviousReferences =
+    config.validatePreviousReferences !== false;
   const secretKey = hexToBytes(config.relayPrivateKey);
   const relayPubkey = getPublicKey(secretKey);
   const seedGroups = config.seedGroups.map((group) => {
@@ -289,7 +291,7 @@ export const createRelayNip29Host = async (
         .flatMap((tag) => tag.slice(1));
 
       if (
-        config.validatePreviousReferences !== false &&
+        validatePreviousReferences &&
         groupId !== undefined &&
         previous.length > 0
       ) {

--- a/src/relay/backends/node/RelayNip29Host.ts
+++ b/src/relay/backends/node/RelayNip29Host.ts
@@ -1,0 +1,364 @@
+/**
+ * Durable NIP-29 relay identity and seed-group host.
+ *
+ * This module keeps deployment values outside the relay library. An operator
+ * supplies one relay signing key and one or more standard NIP-29 seed groups.
+ * The relay publishes `self` through NIP-11 and stores relay-signed group
+ * projections before it starts to accept traffic.
+ */
+import { Effect } from "effect";
+import { hexToBytes } from "@noble/hashes/utils";
+import type { NostrEvent } from "../../../core/Schema.js";
+import { StorageError } from "../../../core/Errors.js";
+import {
+  finalizeEvent,
+  getPublicKey,
+  verifyEvent,
+  type Event as PureEvent,
+} from "../../../wrappers/pure.js";
+import type { EventStore } from "../../storage/EventStore.js";
+import type { NipModule, PreStoreHook } from "../../core/nip/NipModule.js";
+import {
+  createNip29GroupPolicyModule,
+  type Nip29GroupPolicyController,
+} from "../../core/nip/modules/Nip29Module.js";
+import { DefaultModules } from "../../core/nip/modules/index.js";
+import {
+  GROUP_ADMINS_KIND,
+  GROUP_CREATE_GROUP_KIND,
+  GROUP_EDIT_METADATA_KIND,
+  GROUP_JOIN_REQUEST_KIND,
+  GROUP_LEAVE_REQUEST_KIND,
+  GROUP_METADATA_KIND,
+  GROUP_PINNED_EVENTS_KIND,
+  GROUP_PUT_USER_KIND,
+  GROUP_REMOVE_USER_KIND,
+  GROUP_ROLES_KIND,
+  GROUP_UPDATE_PIN_LIST_KIND,
+  getHTag,
+  type EventTemplate,
+  type RoomClass,
+} from "../../../core/Nip29GroupPolicy.js";
+
+const HEX_PRIVATE_KEY = /^[a-f0-9]{64}$/;
+const HEX_EVENT_PREFIX = /^[a-f0-9]{8}$/;
+const PROJECTION_KINDS = [
+  GROUP_METADATA_KIND,
+  GROUP_ADMINS_KIND,
+  GROUP_ROLES_KIND,
+  GROUP_PINNED_EVENTS_KIND,
+] as const;
+const REPLAY_KINDS = [
+  GROUP_PUT_USER_KIND,
+  GROUP_REMOVE_USER_KIND,
+  GROUP_EDIT_METADATA_KIND,
+  GROUP_CREATE_GROUP_KIND,
+  GROUP_UPDATE_PIN_LIST_KIND,
+  GROUP_JOIN_REQUEST_KIND,
+  GROUP_LEAVE_REQUEST_KIND,
+] as const;
+const REGENERATE_KINDS = new Set<number>(REPLAY_KINDS);
+
+export interface RelayNip29SeedGroup {
+  readonly id: string;
+  readonly creatorPubkey?: string;
+  readonly roomClass?: RoomClass;
+  readonly name?: string;
+  readonly about?: string;
+  readonly picture?: string;
+  readonly banner?: string;
+  readonly isPrivate?: boolean;
+  readonly isClosed?: boolean;
+  readonly isRestricted?: boolean;
+  readonly isHidden?: boolean;
+  readonly creatorRoles?: readonly string[];
+  readonly supportedKinds?: readonly number[];
+  readonly pinnedReferences?: readonly (readonly ["e" | "a", string])[];
+}
+
+export interface RelayNip29HostConfig {
+  /** Lowercase 32-byte hex secret supplied by the deployment secret store. */
+  readonly relayPrivateKey: string;
+  /** Groups that must exist before the relay starts to accept traffic. */
+  readonly seedGroups: readonly RelayNip29SeedGroup[];
+  /**
+   * Enforce standard NIP-29 `previous` references when clients provide them.
+   * The NIP allows zero references, so this does not require a tag.
+   */
+  readonly validatePreviousReferences?: boolean;
+}
+
+export interface RelayNip29Host {
+  readonly relayPubkey: string;
+  readonly modules: readonly NipModule[];
+  readonly controller: Nip29GroupPolicyController;
+  readonly seedGroupIds: readonly string[];
+  /** Zero the retained signing-key bytes after the relay stops. */
+  readonly dispose: () => void;
+}
+
+const asNostrEvent = (event: ReturnType<typeof finalizeEvent>): NostrEvent =>
+  event as unknown as NostrEvent;
+
+const normalizeKinds = (kinds: readonly number[] | undefined): readonly number[] | undefined => {
+  if (kinds === undefined) return undefined;
+  const unique = [...new Set(kinds)];
+  if (unique.some((kind) => !Number.isSafeInteger(kind) || kind < 0 || kind > 65_535)) {
+    throw new Error("relay: NIP-29 supportedKinds must contain event kinds");
+  }
+  return unique;
+};
+
+const validateSeedGroup = (group: RelayNip29SeedGroup): void => {
+  if (!/^[a-zA-Z0-9._~:-]{1,128}$/.test(group.id)) {
+    throw new Error(`relay: NIP-29 seed group id is invalid: ${JSON.stringify(group.id)}`);
+  }
+  normalizeKinds(group.supportedKinds);
+  for (const [type, value] of group.pinnedReferences ?? []) {
+    const valid = type === "e" ? /^[a-f0-9]{64}$/.test(value) : /^\d+:[a-f0-9]{64}:.+$/.test(value);
+    if (!valid) {
+      throw new Error(`relay: invalid NIP-29 pinned ${type} reference`);
+    }
+  }
+};
+
+const sameProjection = (
+  event: NostrEvent | undefined,
+  template: EventTemplate,
+  relayPubkey: string,
+): boolean =>
+  event !== undefined &&
+  event.pubkey === relayPubkey &&
+  event.kind === template.kind &&
+  event.content === template.content &&
+  JSON.stringify(event.tags) === JSON.stringify(template.tags) &&
+  verifyEvent(event as unknown as PureEvent);
+
+const templateForKind = (
+  projections: {
+    readonly metadata: EventTemplate;
+    readonly admins: EventTemplate;
+    readonly members: EventTemplate;
+    readonly roles: EventTemplate;
+    readonly pinned: EventTemplate;
+  },
+  kind: (typeof PROJECTION_KINDS)[number],
+): EventTemplate => {
+  switch (kind) {
+    case GROUP_METADATA_KIND:
+      return projections.metadata;
+    case GROUP_ADMINS_KIND:
+      return projections.admins;
+    case GROUP_ROLES_KIND:
+      return projections.roles;
+    case GROUP_PINNED_EVENTS_KIND:
+      return projections.pinned;
+  }
+};
+
+const groupFilter = (groupId: string, kinds: readonly number[], limit?: number) =>
+  ({
+    kinds,
+    "#h": [groupId],
+    ...(limit !== undefined ? { limit } : {}),
+  }) as never;
+
+const projectionFilter = (relayPubkey: string, groupId: string) =>
+  ({
+    authors: [relayPubkey],
+    kinds: [...PROJECTION_KINDS],
+    "#d": [groupId],
+  }) as never;
+
+/**
+ * Create a durable NIP-29 host and write its seed projections.
+ *
+ * The returned module must replace the default advertisement-only NIP-29
+ * module. Startup fails if the key, configuration, replay, or durable write
+ * fails. This prevents a relay from reporting ready with missing state.
+ */
+export const createRelayNip29Host = async (
+  config: RelayNip29HostConfig,
+  eventStore: EventStore,
+): Promise<RelayNip29Host> => {
+  if (!HEX_PRIVATE_KEY.test(config.relayPrivateKey)) {
+    throw new Error("relay: relayPrivateKey must be 64 lowercase hexadecimal characters");
+  }
+  if (config.seedGroups.length === 0) {
+    throw new Error("relay: at least one NIP-29 seed group is required");
+  }
+  for (const group of config.seedGroups) validateSeedGroup(group);
+
+  const secretKey = hexToBytes(config.relayPrivateKey);
+  const relayPubkey = getPublicKey(secretKey);
+  const seedGroups = config.seedGroups.map((group) => {
+    const { supportedKinds, ...groupWithoutSupportedKinds } = group;
+    return {
+      ...groupWithoutSupportedKinds,
+      creatorPubkey: group.creatorPubkey ?? relayPubkey,
+      ...(supportedKinds !== undefined ? { supportedKinds: normalizeKinds(supportedKinds)! } : {}),
+    };
+  });
+  const bundle = createNip29GroupPolicyModule({
+    relayPubkey,
+    seedGroups,
+    defaultClosed: false,
+    defaultRestricted: false,
+  });
+
+  const persistGroupProjections = async (groupId: string): Promise<void> => {
+    const existing = await Effect.runPromise(
+      eventStore.queryEvents([projectionFilter(relayPubkey, groupId)]),
+    );
+    const existingByKind = new Map<number, NostrEvent>(
+      existing.map((event) => [event.kind, event]),
+    );
+    const newestCreatedAt = existing.reduce(
+      (latest, event) => Math.max(latest, event.created_at),
+      0,
+    );
+    const createdAt = Math.max(Math.floor(Date.now() / 1000), newestCreatedAt + 1);
+    const projections = bundle.controller.buildRelaySignedProjections(groupId, createdAt);
+    if (!projections.ok) {
+      throw new Error(
+        `relay: cannot build NIP-29 projections for ${groupId}: ${projections.reason}`,
+      );
+    }
+
+    for (const kind of PROJECTION_KINDS) {
+      const template = templateForKind(projections, kind);
+      if (sameProjection(existingByKind.get(kind), template, relayPubkey)) {
+        continue;
+      }
+      const event = asNostrEvent(
+        finalizeEvent(
+          {
+            ...template,
+            tags: template.tags.map((tag) => [...tag]),
+          },
+          secretKey,
+        ),
+      );
+      const result = await Effect.runPromise(
+        eventStore.storeParameterizedReplaceableEvent(event, groupId),
+      );
+      if (!result.stored && result.reason !== "duplicate") {
+        throw new Error(
+          `relay: could not store NIP-29 projection ${kind}:${groupId} (${result.reason ?? "unknown"})`,
+        );
+      }
+    }
+  };
+
+  // Reconstruct mutations that were durably accepted before this process.
+  // Seed configuration remains the base state; canonical moderation history is
+  // replayed in timestamp and event-id order.
+  for (const group of seedGroups) {
+    const history = await Effect.runPromise(
+      eventStore.queryEvents([groupFilter(group.id, REPLAY_KINDS)]),
+    );
+    const ordered = [...history].sort(
+      (a, b) => a.created_at - b.created_at || a.id.localeCompare(b.id),
+    );
+    for (const event of ordered) {
+      if (event.kind === GROUP_CREATE_GROUP_KIND) continue;
+      const decision = bundle.engine.admitEvent(event);
+      if (!decision.admit) {
+        throw new Error(
+          `relay: stored NIP-29 event ${event.id} cannot be replayed: ${decision.reason}`,
+        );
+      }
+      const applied = bundle.engine.applyEvent(event);
+      if (!applied.applied) {
+        throw new Error(
+          `relay: stored NIP-29 event ${event.id} cannot be applied: ${applied.reason ?? "unknown"}`,
+        );
+      }
+    }
+  }
+
+  for (const group of seedGroups) {
+    await persistGroupProjections(group.id);
+  }
+
+  const durablePreStoreHook: PreStoreHook = (event) =>
+    Effect.gen(function* () {
+      const groupId = getHTag(event);
+      const previous = event.tags
+        .filter((tag) => tag[0] === "previous")
+        .flatMap((tag) => tag.slice(1));
+
+      if (
+        config.validatePreviousReferences !== false &&
+        groupId !== undefined &&
+        previous.length > 0
+      ) {
+        if (previous.some((prefix) => !HEX_EVENT_PREFIX.test(prefix))) {
+          return {
+            action: "reject" as const,
+            reason: "invalid: previous references must be 8 lowercase hexadecimal characters",
+          };
+        }
+        const recent = yield* eventStore.queryEvents([groupFilter(groupId, [], 50)]);
+        const validPrefixes = new Set(
+          recent
+            .filter((prior) => prior.pubkey !== event.pubkey)
+            .map((prior) => prior.id.slice(0, 8)),
+        );
+        if (previous.some((prefix) => !validPrefixes.has(prefix))) {
+          return {
+            action: "reject" as const,
+            reason: "invalid: previous reference is not in this relay group timeline",
+          };
+        }
+      }
+
+      // The durable host applies moderation only after the original event is
+      // stored. This prevents a duplicate or failed write from changing the
+      // in-memory engine without a matching durable event.
+      const decision = bundle.engine.admitEvent(event);
+      if (!decision.admit) {
+        return {
+          action: "reject" as const,
+          reason: decision.reason,
+        };
+      }
+      return { action: "store" as const, event };
+    });
+
+  const durableModule: NipModule = {
+    ...bundle.module,
+    preStoreHook: durablePreStoreHook,
+    postStoreHook: (event) => {
+      const groupId = getHTag(event);
+      if (groupId === undefined || !REGENERATE_KINDS.has(event.kind)) {
+        return Effect.void;
+      }
+      const applied = bundle.engine.applyEvent(event);
+      if (!applied.applied) {
+        return Effect.fail(
+          new StorageError({
+            operation: "upsert",
+            message: `Failed to apply stored NIP-29 event ${event.id}: ${applied.reason ?? "unknown"}`,
+          }),
+        );
+      }
+      return Effect.tryPromise({
+        try: () => persistGroupProjections(groupId),
+        catch: (error) =>
+          new StorageError({
+            operation: "upsert",
+            message: `Failed to regenerate NIP-29 projections: ${error instanceof Error ? error.message : String(error)}`,
+          }),
+      });
+    },
+  };
+
+  return {
+    relayPubkey,
+    modules: [...DefaultModules.filter((module) => module.id !== "nip-29"), durableModule],
+    controller: bundle.controller,
+    seedGroupIds: seedGroups.map((group) => group.id),
+    dispose: () => secretKey.fill(0),
+  };
+};

--- a/src/relay/backends/node/index.ts
+++ b/src/relay/backends/node/index.ts
@@ -46,6 +46,12 @@ import {
   type ConnectionData,
   type LivekitConfig,
 } from "./NodeServer.js"
+export {
+  createRelayNip29Host,
+  type RelayNip29Host,
+  type RelayNip29HostConfig,
+  type RelayNip29SeedGroup,
+} from "./RelayNip29Host.js"
 
 export {
   MemoryEventStoreLive,

--- a/src/relay/core/AuthService.ts
+++ b/src/relay/core/AuthService.ts
@@ -27,6 +27,8 @@ export interface AuthResult {
 
 export interface AuthService {
   readonly _tag: "AuthService"
+  /** Whether this deployment requires authentication for group writes. */
+  readonly authRequired: boolean
 
   /**
    * Get or create a challenge for a connection
@@ -156,6 +158,7 @@ const make = (config: Nip42Config) =>
 
     return {
       _tag: "AuthService" as const,
+      authRequired: config.authRequired === true,
       getChallenge,
       createChallenge,
       handleAuth,

--- a/src/relay/core/MessageHandler.ts
+++ b/src/relay/core/MessageHandler.ts
@@ -168,6 +168,30 @@ const make = (nipRegistry?: NipRegistry, authService?: AuthService) =>
             return { responses: [okMessage(event.id, false, "auth-required: protected event")], broadcasts: [] }
           }
         }
+        // Public NIP-29 groups do not require an application account, but a
+        // deployment that sets NIP-42 auth_required still binds every group
+        // write to the authenticated Nostr key. Reads remain public.
+        if (
+          event.tags.some((t) => t[0] === "h" && t[1]) &&
+          authService?.authRequired === true
+        ) {
+          const authed = yield* authService.isAuthenticated(connectionId)
+          const authedPk = authed
+            ? yield* authService.getAuthPubkey(connectionId)
+            : undefined
+          if (!authed || !authedPk || authedPk !== event.pubkey) {
+            return {
+              responses: [
+                okMessage(
+                  event.id,
+                  false,
+                  "auth-required: NIP-29 group write"
+                ),
+              ],
+              broadcasts: [],
+            }
+          }
+        }
         // NIP-09: Deletion request (kind 5) – e tags and a tags (same pubkey only)
         if (event.kind === 5) {
           // e-tag: delete specific event ids authored by the deleter

--- a/src/relay/core/RelayInfo.ts
+++ b/src/relay/core/RelayInfo.ts
@@ -114,6 +114,8 @@ export const RelayInfo = Schema.Struct({
   contact: Schema.optional(Schema.String),
   /** List of supported NIP numbers */
   supported_nips: Schema.optional(Schema.Array(Schema.Number)),
+  /** Event kinds accepted by this relay deployment */
+  supported_kinds: Schema.optional(Schema.Array(Schema.Number)),
   /** Relay software URL */
   software: Schema.optional(Schema.String),
   /** Software version string */

--- a/src/relay/core/nip/NipModule.ts
+++ b/src/relay/core/nip/NipModule.ts
@@ -8,7 +8,11 @@ import type { Effect } from "effect"
 import type { NostrEvent } from "../../../core/Schema.js"
 import type { Policy } from "../policy/Policy.js"
 import type { RelayInfo, RelayLimitation } from "../RelayInfo.js"
-import type { CryptoError, InvalidPublicKey } from "../../../core/Errors.js"
+import type {
+  CryptoError,
+  InvalidPublicKey,
+  StorageError,
+} from "../../../core/Errors.js"
 import type { EventService } from "../../../services/EventService.js"
 
 // =============================================================================
@@ -27,7 +31,7 @@ export type PreStoreHook = (
   /** NIP-16 ephemeral: OK + live broadcast, do not persist */
   | { readonly action: "broadcast"; readonly event: NostrEvent }
   | { readonly action: "reject"; readonly reason: string },
-  never
+  StorageError
 >
 
 /**
@@ -43,7 +47,9 @@ export interface EventDeleteFilter {
  * Hook called after an event is stored
  * For side effects like notifications, indexing, etc.
  */
-export type PostStoreHook = (event: NostrEvent) => Effect.Effect<void, never>
+export type PostStoreHook = (
+  event: NostrEvent
+) => Effect.Effect<void, StorageError>
 
 /**
  * NIP Module interface

--- a/src/relay/core/nip/NipRegistry.ts
+++ b/src/relay/core/nip/NipRegistry.ts
@@ -6,7 +6,11 @@
  */
 import { Context, Effect, Layer } from "effect"
 import type { NostrEvent } from "../../../core/Schema.js"
-import type { CryptoError, InvalidPublicKey } from "../../../core/Errors.js"
+import type {
+  CryptoError,
+  InvalidPublicKey,
+  StorageError,
+} from "../../../core/Errors.js"
 import { EventService } from "../../../services/EventService.js"
 import { type Policy, all, Accept } from "../policy/Policy.js"
 import {
@@ -55,13 +59,13 @@ export interface NipRegistry {
     | { readonly action: "replace"; readonly event: NostrEvent; readonly deleteFilter?: { kinds?: readonly number[]; authors?: readonly string[]; dTag?: string } }
     | { readonly action: "broadcast"; readonly event: NostrEvent }
     | { readonly action: "reject"; readonly reason: string },
-    never
+    StorageError
   >
 
   /**
    * Run post-store hooks for an event
    */
-  runPostStoreHooks(event: NostrEvent): Effect.Effect<void, never>
+  runPostStoreHooks(event: NostrEvent): Effect.Effect<void, StorageError>
 
   /**
    * Check if a module is registered by ID

--- a/src/relay/core/nip/modules/Nip29Module.ts
+++ b/src/relay/core/nip/modules/Nip29Module.ts
@@ -67,6 +67,8 @@ export interface Nip29GroupPolicyModuleConfig extends GroupPolicyConfig {
     readonly isHidden?: boolean
     readonly creatorRoles?: readonly string[]
     readonly creatorCapabilityGrants?: readonly string[]
+    readonly supportedKinds?: readonly number[]
+    readonly pinnedReferences?: readonly (readonly ["e" | "a", string])[]
   }[]
 }
 
@@ -98,7 +100,7 @@ export interface Nip29GroupPolicyController {
   hasCapabilityGrant: (grantId: string) => boolean
 
   /**
-   * Build unsigned 39000/39001/39002/39003 templates for the host to sign
+   * Build unsigned 39000/39001/39002/39003/39005 templates for the host to sign
    * with the relay key. Clients verify against NIP-11 `self`.
    */
   buildRelaySignedProjections: (
@@ -111,6 +113,7 @@ export interface Nip29GroupPolicyController {
         readonly admins: EventTemplate
         readonly members: EventTemplate
         readonly roles: EventTemplate
+        readonly pinned: EventTemplate
       }
     | { readonly ok: false; readonly reason: string }
 

--- a/src/relay/main.ts
+++ b/src/relay/main.ts
@@ -6,9 +6,15 @@
 import { Effect } from "effect"
 import { startRelayWithEventStore } from "./backends/node/index.js"
 import { openPostgresStore } from "./backends/node/PostgresStore.js"
+import {
+  createRelayNip29Host,
+  type RelayNip29SeedGroup,
+} from "./backends/node/RelayNip29Host.js"
 
 const port = Number(process.env.PORT) || 8080
 const databaseUrl = process.env.DATABASE_URL?.trim()
+const relayPrivateKey = process.env.RELAY_PRIVATE_KEY?.trim()
+const seedGroupsJson = process.env.RELAY_NIP29_SEED_GROUPS?.trim()
 // A relay may legitimately answer on more than one hostname: a custom domain
 // plus its platform hostname during certificate provisioning, or two names
 // during a migration. NIP-42 binds the auth event to the URL the client
@@ -23,6 +29,12 @@ const publicUrls = (process.env.RELAY_PUBLIC_URL ?? "")
 if (databaseUrl === undefined || databaseUrl === "") {
   throw new Error("relay: DATABASE_URL is required")
 }
+if (relayPrivateKey === undefined || relayPrivateKey === "") {
+  throw new Error("relay: RELAY_PRIVATE_KEY is required")
+}
+if (seedGroupsJson === undefined || seedGroupsJson === "") {
+  throw new Error("relay: RELAY_NIP29_SEED_GROUPS is required")
+}
 if (
   publicUrls.length === 0 ||
   !publicUrls.every((value) => /^wss:\/\/[^/?#]+\/?$/.test(value))
@@ -33,21 +45,64 @@ if (
 }
 
 const store = await openPostgresStore(databaseUrl)
-const relay = await startRelayWithEventStore(
-  {
-    port,
-    relayInfo: {
-      name: "OpenAgents Relay",
-      description: "OpenAgents-owned Nostr relay",
-      contact: "mailto:support@openagents.com",
+let seedGroups: readonly RelayNip29SeedGroup[]
+try {
+  const decoded = JSON.parse(seedGroupsJson) as unknown
+  if (!Array.isArray(decoded)) {
+    throw new Error("value must be a JSON array")
+  }
+  seedGroups = decoded as readonly RelayNip29SeedGroup[]
+} catch (error) {
+  await store.close()
+  throw new Error(
+    `relay: RELAY_NIP29_SEED_GROUPS is invalid: ${error instanceof Error ? error.message : String(error)}`
+  )
+}
+
+delete process.env.RELAY_PRIVATE_KEY
+let nip29
+try {
+  nip29 = await createRelayNip29Host(
+    {
+      relayPrivateKey,
+      seedGroups,
     },
-    nip42: {
-      relayUrls: publicUrls,
-      authRequired: true,
+    store.store
+  )
+} catch (error) {
+  await store.close()
+  throw error
+}
+
+let relay
+try {
+  relay = await startRelayWithEventStore(
+    {
+      port,
+      modules: nip29.modules,
+      relayInfo: {
+        name: "OpenAgents Relay",
+        description: "OpenAgents-owned Nostr relay",
+        contact: "mailto:support@openagents.com",
+        self: nip29.relayPubkey,
+        supported_kinds: [
+          ...new Set(
+            seedGroups.flatMap((group) => group.supportedKinds ?? [])
+          ),
+        ].sort((a, b) => a - b),
+      },
+      nip42: {
+        relayUrls: publicUrls,
+        authRequired: true,
+      },
     },
-  },
-  store.store
-)
+    store.store
+  )
+} catch (error) {
+  nip29.dispose()
+  await store.close()
+  throw error
+}
 
 console.log(JSON.stringify({ event: "relay.listening", port: relay.port }))
 
@@ -57,6 +112,7 @@ const stop = async (signal: string): Promise<void> => {
   stopping = true
   console.log(JSON.stringify({ event: "relay.shutdown_start", signal }))
   await Effect.runPromise(relay.stop())
+  nip29.dispose()
   await store.close()
   console.log(JSON.stringify({ event: "relay.shutdown_done" }))
 }

--- a/src/relay/main.ts
+++ b/src/relay/main.ts
@@ -13,7 +13,7 @@ import {
 
 const port = Number(process.env.PORT) || 8080
 const databaseUrl = process.env.DATABASE_URL?.trim()
-const relayPrivateKey = process.env.RELAY_PRIVATE_KEY?.trim()
+let relayPrivateKey = process.env.RELAY_PRIVATE_KEY?.trim()
 const seedGroupsJson = process.env.RELAY_NIP29_SEED_GROUPS?.trim()
 // A relay may legitimately answer on more than one hostname: a custom domain
 // plus its platform hostname during certificate provisioning, or two names
@@ -59,7 +59,6 @@ try {
   )
 }
 
-delete process.env.RELAY_PRIVATE_KEY
 let nip29
 try {
   nip29 = await createRelayNip29Host(
@@ -72,6 +71,9 @@ try {
 } catch (error) {
   await store.close()
   throw error
+} finally {
+  relayPrivateKey = ""
+  delete process.env.RELAY_PRIVATE_KEY
 }
 
 let relay


### PR DESCRIPTION
Closes #171

## Summary

- load a generic relay signing identity and seed-group configuration from deployment inputs
- expose NIP-11 `self` and `supported_kinds`
- sign and durably upsert kinds 39000, 39001, 39003, and 39005 before listener readiness
- replay stored moderation state on restart and regenerate projections after metadata, membership, and pin changes
- validate optional NIP-29 `previous` references as 8-character prefixes from the relay group timeline
- require same-pubkey NIP-42 authentication for NIP-29 group writes when `auth_required` is enabled; reads stay public
- keep all group ids, metadata, kinds, and signing material operator-configured

## Verification

- `pnpm run verify:postgres`
- 156 test files, 1472 tests passed against a provisioned Postgres 17 store
- pre-push repeated the same full Postgres verification and passed

## Operating boundary

Restart state is durable through moderation replay. The policy engine is process-local, so production must use one relay instance for moderation writes until shared coordination exists.