### PR TITLE
fix(relay): advertise restricted NIP-29 writes

### DIFF
--- a/src/relay/main.ts
+++ b/src/relay/main.ts
@@ -92,6 +92,9 @@ try {
             seedGroups.flatMap((group) => group.supportedKinds ?? [])
           ),
         ].sort((a, b) => a - b),
+        limitation: {
+          restricted_writes: true,
+        },
       },
       nip42: {
         relayUrls: publicUrls,


### PR DESCRIPTION
Follow-up for #171. The relay keeps public REQ/read access, requires same-pubkey NIP-42 for group writes, and now advertises `limitation.restricted_writes=true` instead of publishing a null limitation.\n\nVerification: `pnpm run verify:postgres` (156 files, 1,472 tests, Postgres 17 postflight).