### PR TITLE
fix(relay): emit only standard NIP-29 metadata tags

### DIFF
--- a/src/core/Nip29GroupPolicy.ts
+++ b/src/core/Nip29GroupPolicy.ts
@@ -1119,9 +1119,6 @@ export class GroupPolicyEngine {
         ...g.supportedKinds.map((kind) => String(kind)),
       ])
     }
-    // Room class as a non-conflicting extension tag for operators.
-    metadataTags.push(["room-class", g.roomClass])
-
     const adminTags: string[][] = [["d", groupId]]
     const memberTags: string[][] = [["d", groupId]]
     for (const m of g.members.values()) {

--- a/src/relay/backends/node/RelayNip29Host.test.ts
+++ b/src/relay/backends/node/RelayNip29Host.test.ts
@@ -150,6 +150,7 @@ describe("RelayNip29Host", () => {
     expect(initialState.every((event) => event.pubkey === firstHost.relayPubkey)).toBe(true);
     const metadata = initialState.find((event) => event.kind === 39000);
     expect(metadata?.tags).toContainEqual(["supported_kinds", "5", "7", "9", "1337", "1984"]);
+    expect(metadata?.tags.some((tag) => tag[0] === "room-class")).toBe(false);
 
     const port = 33_000 + Math.floor(Math.random() * 5_000);
     const relay: RelayHandle = await startRelayWithEventStore(


### PR DESCRIPTION
Follow-up for #171. Remove the deployment-specific `room-class` extension from relay-signed kind 39000. The public group now emits only standard NIP-29 metadata tags.\n\nVerification: `pnpm run verify:postgres` (156 files, 1,472 tests, Postgres 17 postflight).